### PR TITLE
FI-1407: Use oauth_credentials

### DIFF
--- a/lib/smart_app_launch/ehr_launch_group.rb
+++ b/lib/smart_app_launch/ehr_launch_group.rb
@@ -81,6 +81,9 @@ module SMARTAppLaunch
         },
         launch: {
           name: :ehr_launch
+        },
+        smart_credentials: {
+          name: :ehr_smart_credentials
         }
       },
       outputs: {
@@ -95,7 +98,8 @@ module SMARTAppLaunch
         patient_id: { name: :ehr_patient_id },
         encounter_id: { name: :ehr_encounter_id },
         received_scopes: { name: :ehr_received_scopes },
-        intent: { name: :ehr_intent }
+        intent: { name: :ehr_intent },
+        smart_credentials: { name: :ehr_smart_credentials }
       },
       requests: {
         launch: { name: :ehr_launch },

--- a/lib/smart_app_launch/openid_fhir_user_claim_test.rb
+++ b/lib/smart_app_launch/openid_fhir_user_claim_test.rb
@@ -8,12 +8,13 @@ module SMARTAppLaunch
       the url for a Patient, Practitioner, RelatedPerson, or Person resource
     )
 
-    input :id_token_payload_json, :requested_scopes, :url, :access_token
+    input :id_token_payload_json, :requested_scopes, :url
+    input :smart_credentials, type: :oauth_credentials
     output :id_token_fhir_user
 
     fhir_client do
       url :url
-      bearer_token :access_token
+      oauth_credentials :smart_credentials
     end
 
     run do

--- a/lib/smart_app_launch/standalone_launch_group.rb
+++ b/lib/smart_app_launch/standalone_launch_group.rb
@@ -74,7 +74,11 @@ module SMARTAppLaunch
         },
         state: {
           name: :standalone_state
+        },
+        smart_credentials: {
+          name: :standalone_smart_credentials
         }
+
       },
       outputs: {
         code: { name: :standalone_code },
@@ -87,7 +91,8 @@ module SMARTAppLaunch
         patient_id: { name: :standalone_patient_id },
         encounter_id: { name: :standalone_encounter_id },
         received_scopes: { name: :standalone_received_scopes },
-        intent: { name: :standalone_intent }
+        intent: { name: :standalone_intent },
+        smart_credentials: { name: :standalone_smart_credentials }
       },
       requests: {
         redirect: { name: :standalone_redirect },

--- a/lib/smart_app_launch/token_exchange_test.rb
+++ b/lib/smart_app_launch/token_exchange_test.rb
@@ -32,6 +32,7 @@ module SMARTAppLaunch
           }
     input :pkce_code_verifier, optional: true
     output :token_retrieval_time
+    output :smart_credentials
     uses_request :redirect
     makes_request :token
 
@@ -60,9 +61,21 @@ module SMARTAppLaunch
 
       post(smart_token_url, body: oauth2_params, name: :token, headers: oauth2_headers)
 
+      assert_response_status(200)
+      assert_valid_json(request.response_body)
+
       output token_retrieval_time: Time.now.iso8601
 
-      assert_response_status(200)
+      token_response_body = JSON.parse(request.response_body)
+      output smart_credentials: {
+               refresh_token: token_response_body['refresh_token'],
+               access_token: token_response_body['access_token'],
+               expires_in: token_response_body['expires_in'],
+               client_id: client_id,
+               client_secret: client_secret,
+               token_retrieval_time: token_retrieval_time,
+               token_url: smart_token_url
+             }.to_json
     end
   end
 end

--- a/lib/smart_app_launch/token_refresh_test.rb
+++ b/lib/smart_app_launch/token_refresh_test.rb
@@ -18,6 +18,7 @@ module SMARTAppLaunch
     )
     input :well_known_token_url, :refresh_token, :client_id, :received_scopes
     input :client_secret, optional: true
+    output :smart_credentials, :token_retrieval_time
     makes_request :token_refresh
 
     run do
@@ -41,7 +42,20 @@ module SMARTAppLaunch
       post(well_known_token_url, body: oauth2_params, name: :token_refresh, headers: oauth2_headers)
 
       assert_response_status(200)
-      assert_valid_json(response[:body])
+      assert_valid_json(request.response_body)
+
+      output token_retrieval_time: Time.now.iso8601
+
+      token_response_body = JSON.parse(request.response_body)
+      output smart_credentials: {
+               refresh_token: token_response_body['refresh_token'],
+               access_token: token_response_body['access_token'],
+               expires_in: token_response_body['expires_in'],
+               client_id: client_id,
+               client_secret: client_secret,
+               token_retrieval_time: token_retrieval_time,
+               token_url: well_known_token_url
+             }.to_json
     end
   end
 end

--- a/lib/smart_app_launch_test_kit.rb
+++ b/lib/smart_app_launch_test_kit.rb
@@ -58,7 +58,8 @@ module SMARTAppLaunch
                 id_token: { name: :standalone_id_token },
                 client_id: { name: :standalone_client_id },
                 requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token }
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
               }
             }
 
@@ -77,7 +78,8 @@ module SMARTAppLaunch
                 received_scopes: { name: :standalone_received_scopes },
                 access_token: { name: :standalone_access_token },
                 token_retrieval_time: { name: :standalone_token_retrieval_time },
-                expires_in: { name: :standalone_expires_in }
+                expires_in: { name: :standalone_expires_in },
+                smart_credentials: { name: :standalone_smart_credentials }
               }
             }
 
@@ -97,7 +99,8 @@ module SMARTAppLaunch
                 received_scopes: { name: :standalone_received_scopes },
                 access_token: { name: :standalone_access_token },
                 token_retrieval_time: { name: :standalone_token_retrieval_time },
-                expires_in: { name: :standalone_expires_in }
+                expires_in: { name: :standalone_expires_in },
+                smart_credentials: { name: :standalone_smart_credentials }
               }
             }
     end
@@ -118,7 +121,8 @@ module SMARTAppLaunch
                 id_token: { name: :ehr_id_token },
                 client_id: { name: :ehr_client_id },
                 requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token }
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
               }
             }
 
@@ -137,7 +141,8 @@ module SMARTAppLaunch
                 received_scopes: { name: :ehr_received_scopes },
                 access_token: { name: :ehr_access_token },
                 token_retrieval_time: { name: :ehr_token_retrieval_time },
-                expires_in: { name: :ehr_expires_in }
+                expires_in: { name: :ehr_expires_in },
+                smart_credentials: { name: :ehr_smart_credentials }
               }
             }
 
@@ -157,7 +162,8 @@ module SMARTAppLaunch
                 received_scopes: { name: :ehr_received_scopes },
                 access_token: { name: :ehr_access_token },
                 token_retrieval_time: { name: :ehr_token_retrieval_time },
-                expires_in: { name: :ehr_expires_in }
+                expires_in: { name: :ehr_expires_in },
+                smart_credentials: { name: :ehr_smart_credentials }
               }
             }
     end

--- a/spec/smart_app_launch/token_exchange_test_spec.rb
+++ b/spec/smart_app_launch/token_exchange_test_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
             },
           headers: { 'Authorization' => "Basic #{Base64.strict_encode64('CLIENT_ID:CLIENT_SECRET')}" }
         )
-        .to_return(status: 200)
+        .to_return(status: 200, body: {}.to_json)
 
       result = run(test, confidential_inputs)
 
@@ -79,7 +79,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
               redirect_uri: described_class.config.options[:redirect_uri]
             }
         )
-        .to_return(status: 200)
+        .to_return(status: 200, body: {}.to_json)
 
       result = run(test, public_inputs)
 
@@ -131,7 +131,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
                 code_verifier: 'CODE_VERIFIER'
               }
           )
-          .to_return(status: 200)
+          .to_return(status: 200, body: {}.to_json)
 
       result = run(test, public_inputs.merge(use_pkce: 'true', pkce_code_verifier: 'CODE_VERIFIER'))
 


### PR DESCRIPTION
Update test kit to output `oauth_credentials` so fhir client tokens can automatically refresh.