### PR TITLE
FI-1490: Validate Granted Refresh Scopes are Subset of Originally Granted Scopes

### DIFF
--- a/lib/smart_app_launch/token_payload_validation.rb
+++ b/lib/smart_app_launch/token_payload_validation.rb
@@ -28,6 +28,12 @@ module SMARTAppLaunch
       end
     end
 
+    def validate_scope_subset(received_scopes, original_scopes)
+      extra_scopes = received_scopes.split - original_scopes.split
+      assert extra_scopes.empty?, "Token response contained scopes which are not a subset of the scope granted to the "\
+                                  "original access token: #{extra_scopes.join(', ')}"
+    end
+
     def validate_token_field_types(body)
       STRING_FIELDS
         .select { |field| body[field].present? }

--- a/lib/smart_app_launch/token_refresh_body_test.rb
+++ b/lib/smart_app_launch/token_refresh_body_test.rb
@@ -36,8 +36,7 @@ module SMARTAppLaunch
       validate_token_field_types(body)
       validate_token_type(body)
 
-      assert received_scopes.split.sort == old_received_scopes.split.sort,
-             'Received scopes not equal to originally granted scopes'
+      validate_scope_subset(received_scopes, old_received_scopes)
     end
   end
 end

--- a/lib/smart_app_launch/token_refresh_body_test.rb
+++ b/lib/smart_app_launch/token_refresh_body_test.rb
@@ -11,6 +11,8 @@ module SMARTAppLaunch
       an access token or a message indicating that the authorization request
       has been denied. `access_token`, `expires_in`, `token_type`, and `scope` are
       required. `access_token` must be `Bearer`.
+
+      Scopes returned must be a strict subset of the scopes granted in the original launch.
     )
     input :received_scopes
     output :refresh_token, :access_token, :token_retrieval_time, :expires_in, :received_scopes

--- a/lib/smart_app_launch/token_refresh_group.rb
+++ b/lib/smart_app_launch/token_refresh_group.rb
@@ -10,7 +10,7 @@ module SMARTAppLaunch
     description %(
       # Background
 
-      The #{title} Sequence tests the ability of the system to successfuly
+      The #{title} Sequence tests the ability of the system to successfully
       exchange a refresh token for an access token. Refresh tokens are typically
       longer lived than access tokens and allow client applications to obtain a
       new access token Refresh tokens themselves cannot provide access to

--- a/spec/smart_app_launch/token_refresh_body_test_spec.rb
+++ b/spec/smart_app_launch/token_refresh_body_test_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe SMARTAppLaunch::TokenRefreshBodyTest do
     expect(result.result_message).to match(/bearer/)
   end
 
-  it 'fails if scopes do not match the original scopes' do
+  it 'fails if scopes are not a subset of the original scopes' do
     body = valid_body
     body[:scope] += ' user/*.*'
     create_token_refresh_request(body: body)
@@ -111,7 +111,19 @@ RSpec.describe SMARTAppLaunch::TokenRefreshBodyTest do
     result = run(test, received_scopes: received_scopes)
 
     expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/scopes not equal/)
+    expect(result.result_message).to match(/contained scopes which are not a subset/)
+  end
+
+  it 'passes if the scopes are a subset of the original scopes' do
+    body = valid_body
+    body[:scope] = body[:scope].split
+    body[:scope].pop
+    body[:scope] = body[:scope].join(' ')
+    create_token_refresh_request(body: body)
+
+    result = run(test, received_scopes: received_scopes)
+
+    expect(result.result).to eq('pass')
   end
 
   it 'fails is the fields are the wrong types' do


### PR DESCRIPTION
The current refresh token body test checks that granted refresh token scopes are _fully equivalent_ to the originally granted scopes. This PR relaxes that check to ensure that granted refresh tokens are a _strict subset_ of the originally granted scopes.

Note: We'll need to update the `.gempspec` in the g10 to use this once we have this approved and a new version published.

References:
https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/39
https://github.com/onc-healthit/inferno/issues/464
https://jira.hl7.org/browse/FHIR-36272
https://chat.fhir.org/#narrow/stream/179170-smart/topic/Expected.20scopes.20on.20a.20.22refreshed.22.20access.20token