### PR TITLE
FI-1563 `.well-known/smart-configuration` Request Accept Header

### DIFF
--- a/lib/smart_app_launch/discovery_group.rb
+++ b/lib/smart_app_launch/discovery_group.rb
@@ -56,7 +56,9 @@ module SMARTAppLaunch
 
       run do
         well_known_configuration_url = "#{url.chomp('/')}/.well-known/smart-configuration"
-        get(well_known_configuration_url, name: :smart_well_known_configuration)
+        get(well_known_configuration_url,
+            name: :smart_well_known_configuration,
+            headers: { 'Accept' => 'application/json' })
 
         assert_response_status(200)
 

--- a/spec/smart_app_launch/discovery_group_spec.rb
+++ b/spec/smart_app_launch/discovery_group_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe SMARTAppLaunch::DiscoveryGroup do
       expect(result.result).to eq('pass')
     end
 
+    it 'sends an Accept Header with application/json' do
+      request = stub_request(:get, well_known_url)
+        .to_return(status: 200, body: well_known_config.to_json, headers: { 'Content-Type' => 'application/json' })
+      result = run(runnable, url: url)
+      
+      expect(a_request(:get, well_known_url).with(headers: {'Accept' => 'application/json'})).to have_been_made.once
+    end
+
     it 'fails when a non-200 response is received' do
       stub_request(:get, well_known_url)
         .to_return(status: 201, body: well_known_config.to_json, headers: { 'Content-Type' => 'application/json' })


### PR DESCRIPTION
Adds an `Accept: application/json` header to the `FHIR server makes SMART configuration available from well-known endpoint` test.