### PR TITLE
FI-1567: Support POST auth

### DIFF
--- a/config/presets/inferno_reference_server_stu2_preset.json
+++ b/config/presets/inferno_reference_server_stu2_preset.json
@@ -19,43 +19,6 @@
       "value": "launch/patient openid fhirUser offline_access patient/*.read"
     },
     {
-      "name": "use_pkce",
-      "type": "radio",
-      "title": "Proof Key for Code Exchange (PKCE)",
-      "options": {
-        "list_options": [
-          {
-            "label": "Enabled",
-            "value": "true"
-          },
-          {
-            "label": "Disabled",
-            "value": "false"
-          }
-        ]
-      },
-      "value": "false"
-    },
-    {
-      "name": "pkce_code_challenge_method",
-      "type": "radio",
-      "optional": true,
-      "title": "PKCE Code Challenge Method",
-      "options": {
-        "list_options": [
-          {
-            "label": "S256",
-            "value": "S256"
-          },
-          {
-            "label": "plain",
-            "value": "plain"
-          }
-        ]
-      },
-      "value": "S256"
-    },
-    {
       "name": "standalone_client_secret",
       "type": "text",
       "optional": true,

--- a/lib/smart_app_launch/app_redirect_test_stu2.rb
+++ b/lib/smart_app_launch/app_redirect_test_stu2.rb
@@ -1,0 +1,45 @@
+require 'uri'
+require_relative 'app_redirect_test'
+
+module SMARTAppLaunch
+  class AppRedirectTestSTU2 < AppRedirectTest
+    id :smart_app_redirect_stu2
+    description %(
+      Client browser redirected from OAuth server to redirect URI of client
+      app as described in SMART authorization sequence.
+
+      Client SHALL use either the HTTP GET or the HTTP POST method to send the
+      Authorization Request to the Authorization Server.
+
+      [Authorization Code
+      Request](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#request-4)
+    )
+
+    input :authorization_method,
+          title: 'Authorization Method',
+          type: 'radio',
+          default: 'get',
+          options: {
+            list_options: [
+              {
+                label: 'GET',
+                value: 'get'
+              },
+              {
+                label: 'POST',
+                value: 'post'
+              }
+            ]
+          }
+
+    def authorization_url_builder(url, params)
+      return super if authorization_method == 'get'
+
+      post_params = params.merge(auth_url: url)
+
+      post_url = URI(config.options[:post_authorization_uri])
+      post_url.query = URI.encode_www_form(post_params)
+      post_url.to_s
+    end
+  end
+end

--- a/lib/smart_app_launch/ehr_launch_group_stu2.rb
+++ b/lib/smart_app_launch/ehr_launch_group_stu2.rb
@@ -1,3 +1,4 @@
+require_relative 'app_redirect_test_stu2'
 require_relative 'ehr_launch_group'
 
 module SMARTAppLaunch
@@ -41,5 +42,12 @@ module SMARTAppLaunch
         }
       }
     )
+
+    test from: :smart_app_redirect_stu2 do
+      input :launch
+    end
+
+    redirect_index = children.find_index { |child| child.id.to_s.end_with? 'app_redirect' }
+    children[redirect_index] = children.pop
   end
 end

--- a/lib/smart_app_launch/post_auth.html
+++ b/lib/smart_app_launch/post_auth.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Use the highest supported document mode of Internet Explorer -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta charset="utf-8" />
+    <title>Inferno POST Authorization Redirect</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <form id="form" style="display:none;">
+    </form>
+  </body>
+  <script>
+    const params = Object.fromEntries(new URLSearchParams(window.location.search).entries());
+    const submitUrl = params.auth_url;
+    delete params.auth_url;
+    const form = document.getElementById('form');
+    form.method = 'POST';
+    form.action = submitUrl;
+
+    for (const property in params) {
+      let input = document.createElement('input');
+      input.setAttribute('name', property);
+      input.setAttribute('value', params[property]);
+
+      form.appendChild(input);
+    }
+
+    form.submit();
+  </script>
+</html>

--- a/lib/smart_app_launch/post_auth.html
+++ b/lib/smart_app_launch/post_auth.html
@@ -23,7 +23,9 @@
     for (const property in params) {
       let input = document.createElement('input');
       input.setAttribute('name', property);
-      input.setAttribute('value', params[property]);
+
+      let value = params[property].replace(/\+/g, ' ');
+      input.setAttribute('value', decodeURIComponent(value));
 
       form.appendChild(input);
     }

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -21,9 +21,15 @@ module SMARTAppLaunch
       request.query_parameters['state']
     end
 
+    @post_auth_page = File.read(File.join(__dir__, 'post_auth.html'))
+    post_auth_handler = proc { [200, {}, [@post_auth_page]] }
+
+    route :get, '/post_auth', post_auth_handler
+
     config options: {
-      redirect_uri: "#{Inferno::Application['base_url']}/custom/smart/redirect",
-      launch_uri: "#{Inferno::Application['base_url']}/custom/smart/launch"
+      redirect_uri: "#{Inferno::Application['base_url']}/custom/smart_stu2/redirect",
+      launch_uri: "#{Inferno::Application['base_url']}/custom/smart_stu2/launch",
+      post_authorization_uri: "#{Inferno::Application['base_url']}/custom/smart_stu2/post_auth"
     }
 
     group do

--- a/lib/smart_app_launch/standalone_launch_group_stu2.rb
+++ b/lib/smart_app_launch/standalone_launch_group_stu2.rb
@@ -1,3 +1,4 @@
+require_relative 'app_redirect_test_stu2'
 require_relative 'standalone_launch_group'
 
 module SMARTAppLaunch
@@ -39,5 +40,10 @@ module SMARTAppLaunch
         }
       }
     )
+
+    test from: :smart_app_redirect_stu2
+
+    redirect_index = children.find_index { |child| child.id.to_s.end_with? 'app_redirect' }
+    children[redirect_index] = children.pop
   end
 end

--- a/smart_app_launch_test_kit.gemspec
+++ b/smart_app_launch_test_kit.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/inferno_framework/smart-app-launch-test-kit'
   spec.files = [
     Dir['lib/**/*.rb'],
+    Dir['lib/**/*.html'],
     Dir['lib/**/*.json'],
     'LICENSE'
   ].flatten


### PR DESCRIPTION
This branch adds support for using POST for the auth request. The reference server does not currently support POST-based auth, but you can check that the request is correct in the browser.

![Screen Shot 2022-07-06 at 11 03 47 AM](https://user-images.githubusercontent.com/15969967/177582433-5439871b-74fa-4cdf-ad9b-8b61d21502f1.png)