### PR TITLE
FI-1566: use SMARTv2 scopes

### DIFF
--- a/lib/smart_app_launch/ehr_launch_group_stu2.rb
+++ b/lib/smart_app_launch/ehr_launch_group_stu2.rb
@@ -41,7 +41,7 @@ module SMARTAppLaunch
           locked: true
         },
         requested_scopes: {
-          default: 'launch openid fhirUser offline_access user/*.r'
+          default: 'launch openid fhirUser offline_access user/*.rs'
         }
       }
     )

--- a/lib/smart_app_launch/ehr_launch_group_stu2.rb
+++ b/lib/smart_app_launch/ehr_launch_group_stu2.rb
@@ -39,6 +39,9 @@ module SMARTAppLaunch
         pkce_code_challenge_method: {
           default: 'S256',
           locked: true
+        },
+        requested_scopes: {
+          default: 'launch openid fhirUser offline_access user/*.r'
         }
       }
     )

--- a/lib/smart_app_launch/standalone_launch_group_stu2.rb
+++ b/lib/smart_app_launch/standalone_launch_group_stu2.rb
@@ -39,7 +39,7 @@ module SMARTAppLaunch
           locked: true
         },
         requested_scopes: {
-          default: 'launch/patient openid fhirUser offline_access patient/*.r'
+          default: 'launch/patient openid fhirUser offline_access patient/*.rs'
         }
       }
     )

--- a/lib/smart_app_launch/standalone_launch_group_stu2.rb
+++ b/lib/smart_app_launch/standalone_launch_group_stu2.rb
@@ -37,6 +37,9 @@ module SMARTAppLaunch
         pkce_code_challenge_method: {
           default: 'S256',
           locked: true
+        },
+        requested_scopes: {
+          default: 'launch/patient openid fhirUser offline_access patient/*.r'
         }
       }
     )


### PR DESCRIPTION
# Summary

Use SMARTv2 style scopes by default in the STU2 tests.

# Testing

Try to running the standalone launch and ehr launch tests. Both should use the SMARTv2 style scopes (e.g. `patient.r`)


Test with Docker using:
```shell
./setup.sh
./run.sh
```

Or directly with a native ruby installation:

```shell
bundle exec inferno migrate
ASYNC_JOBS=false INFERNO_HOST=http://localhost:4567 bundle exec puma
```

# Notes

The token payload validation methods are based on the requested and received scopes and shouldn't need any changes.
https://github.com/inferno-framework/smart-app-launch-test-kit/blob/170d9fae0961c3c19ec0e7693900e25578db53eb/lib/smart_app_launch/token_payload_validation.rb#L31-L35

We might want to add a ticket to the backlog to make this token refresh subset validation method a little smarter for both STU1 and STU2.

e.g. if we request `patient/.*` (STU1) or `patient.cruds` (STU2) and on refresh get back `patient.read` or `patient.r` then that should be a valid subset. At least that's how I think it would be interpreted.