### PR TITLE
FI-1694: Fix discovery group crash

### DIFF
--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -71,13 +71,14 @@ module SMARTAppLaunch
           resource
             .rest
             &.map(&:security)
+            &.compact
             &.find do |security|
-            security.service&.any? do |service|
-              service.coding&.any? do |coding|
-                coding.code == 'SMART-on-FHIR'
+              security.service&.any? do |service|
+                service.coding&.any? do |coding|
+                  coding.code == 'SMART-on-FHIR'
+                end
               end
             end
-          end
             &.extension
             &.find do |extension|
               extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris'

--- a/spec/smart_app_launch/discovery_group_spec.rb
+++ b/spec/smart_app_launch/discovery_group_spec.rb
@@ -44,7 +44,17 @@ RSpec.describe SMARTAppLaunch::DiscoverySTU1Group do
 
   describe 'capability statement test' do
     let(:runnable) { group.tests[2] }
-    let(:minimal_capabilities) { FHIR::CapabilityStatement.new(fhirVersion: '4.0.1') }
+    let(:minimal_capabilities) do
+      FHIR::CapabilityStatement.new(
+        fhirVersion: '4.0.1',
+        rest: [
+          {
+            mode: 'server'
+          }
+        ]
+      )
+    end
+
     let(:full_extensions) do
       [
         {


### PR DESCRIPTION
# Summary
This branch fixes a nil-safety issue which caused a purple error when `CapabilityStatement.rest.security` was nil (see https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/233).

# Testing Guidance
If you check out the first commit in this branch, the unit tests will fail due to a purple error, which is resolved in the subsequent commit.
