### PR TITLE
Remove (Work in Progress) from title.

### DIFF
--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -10,7 +10,7 @@ require_relative 'token_refresh_group'
 module SMARTAppLaunch
   class SMARTSTU2Suite < Inferno::TestSuite
     id 'smart_stu2'
-    title 'SMART App Launch STU2 (Work in Progress)'
+    title 'SMART App Launch STU2'
     version VERSION
 
     resume_test_route :get, '/launch' do


### PR DESCRIPTION
# Summary
If SMART App Launch STU2 is stable, we should remove the 'Work in progress', as it is not a great look when running the g10 test kit locally:

<img width="834" alt="Screen Shot 2022-09-09 at 3 46 11 PM" src="https://user-images.githubusercontent.com/412901/189443178-547e7d4b-1f00-40d4-b580-12901b172d53.png">

# Testing Guidance
This should just update the title to not include 'Work in Progress'.
