### PR TITLE
FI-1717: Handle Relative SMART Links

### DIFF
--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -94,7 +94,7 @@ module SMARTAppLaunch
         base_url = url.chomp('/') + '/'
         oauth_urls = oauth_extension_urls.each_with_object({}) do |url, urls|
           urls[url] = smart_extension.extension.find { |extension| extension.url == url }&.valueUri
-          make_url_absolute(base_url, urls[url])
+          urls[url] = make_url_absolute(base_url, urls[url])
         end
 
         output capability_authorization_url: oauth_urls['authorize'],

--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -91,7 +91,7 @@ module SMARTAppLaunch
 
         oauth_extension_urls = ['authorize', 'introspect', 'manage', 'register', 'revoke', 'token']
 
-        base_url = url.chomp('/') + '/'
+      base_url = "#{url.chomp('/')}/"
         oauth_urls = oauth_extension_urls.each_with_object({}) do |url, urls|
           urls[url] = smart_extension.extension.find { |extension| extension.url == url }&.valueUri
           urls[url] = make_url_absolute(base_url, urls[url])

--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -91,9 +91,10 @@ module SMARTAppLaunch
 
         oauth_extension_urls = ['authorize', 'introspect', 'manage', 'register', 'revoke', 'token']
 
+        base_url = url.chomp('/') + '/'
         oauth_urls = oauth_extension_urls.each_with_object({}) do |url, urls|
           urls[url] = smart_extension.extension.find { |extension| extension.url == url }&.valueUri
-          make_url_absolute(url, urls[url])
+          make_url_absolute(base_url, urls[url])
         end
 
         output capability_authorization_url: oauth_urls['authorize'],

--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -1,5 +1,6 @@
 require_relative 'well_known_capabilities_stu1_test'
 require_relative 'well_known_endpoint_test'
+require_relative 'url_helpers'
 
 module SMARTAppLaunch
   class DiscoverySTU1Group < Inferno::TestGroup
@@ -45,6 +46,8 @@ module SMARTAppLaunch
          id: 'Test02'
 
     test do
+      include URLHelpers
+
       title 'Conformance/CapabilityStatement provides OAuth 2.0 endpoints'
       description %(
         If a server requires SMART on FHIR authorization for access, its
@@ -90,6 +93,7 @@ module SMARTAppLaunch
 
         oauth_urls = oauth_extension_urls.each_with_object({}) do |url, urls|
           urls[url] = smart_extension.extension.find { |extension| extension.url == url }&.valueUri
+          make_url_absolute(url, urls[url])
         end
 
         output capability_authorization_url: oauth_urls['authorize'],

--- a/lib/smart_app_launch/url_helpers.rb
+++ b/lib/smart_app_launch/url_helpers.rb
@@ -1,0 +1,7 @@
+module SMARTAppLaunch
+  module URLHelpers
+    def make_url_absolute(base_url, endpoint)
+      endpoint ? URI.join(base_url, endpoint).to_s : endpoint
+    end
+  end
+end

--- a/lib/smart_app_launch/well_known_endpoint_test.rb
+++ b/lib/smart_app_launch/well_known_endpoint_test.rb
@@ -1,5 +1,9 @@
+require_relative 'url_helpers'
+
 module SMARTAppLaunch
   class WellKnownEndpointTest < Inferno::Test
+    include URLHelpers
+
     title 'FHIR server makes SMART configuration available from well-known endpoint'
     id :well_known_endpoint
     description %(
@@ -29,12 +33,12 @@ module SMARTAppLaunch
 
       config = JSON.parse(request.response_body)
       output well_known_configuration: request.response_body,
-             well_known_authorization_url: config['authorization_endpoint'],
-             well_known_introspection_url: config['introspection_endpoint'],
-             well_known_management_url: config['management_endpoint'],
-             well_known_registration_url: config['registration_endpoint'],
-             well_known_revocation_url: config['revocation_endpoint'],
-             well_known_token_url: config['token_endpoint']
+             well_known_authorization_url: make_url_absolute(url, config['authorization_endpoint']),
+             well_known_introspection_url: make_url_absolute(url, config['introspection_endpoint']),
+             well_known_management_url: make_url_absolute(url, config['management_endpoint']),
+             well_known_registration_url: make_url_absolute(url, config['registration_endpoint']),
+             well_known_revocation_url: make_url_absolute(url, config['revocation_endpoint']),
+             well_known_token_url: make_url_absolute(url, config['token_endpoint'])
 
       content_type = request.response_header('Content-Type')&.value
 

--- a/lib/smart_app_launch/well_known_endpoint_test.rb
+++ b/lib/smart_app_launch/well_known_endpoint_test.rb
@@ -31,14 +31,16 @@ module SMARTAppLaunch
 
       assert_valid_json(request.response_body)
 
+      base_url = "#{url.chomp('/')}/"
       config = JSON.parse(request.response_body)
+
       output well_known_configuration: request.response_body,
-             well_known_authorization_url: make_url_absolute(url, config['authorization_endpoint']),
-             well_known_introspection_url: make_url_absolute(url, config['introspection_endpoint']),
-             well_known_management_url: make_url_absolute(url, config['management_endpoint']),
-             well_known_registration_url: make_url_absolute(url, config['registration_endpoint']),
-             well_known_revocation_url: make_url_absolute(url, config['revocation_endpoint']),
-             well_known_token_url: make_url_absolute(url, config['token_endpoint'])
+             well_known_authorization_url: make_url_absolute(base_url, config['authorization_endpoint']),
+             well_known_introspection_url: make_url_absolute(base_url, config['introspection_endpoint']),
+             well_known_management_url: make_url_absolute(base_url, config['management_endpoint']),
+             well_known_registration_url: make_url_absolute(base_url, config['registration_endpoint']),
+             well_known_revocation_url: make_url_absolute(base_url, config['revocation_endpoint']),
+             well_known_token_url: make_url_absolute(base_url, config['token_endpoint'])
 
       content_type = request.response_header('Content-Type')&.value
 

--- a/spec/smart_app_launch/discovery_group_spec.rb
+++ b/spec/smart_app_launch/discovery_group_spec.rb
@@ -85,6 +85,36 @@ RSpec.describe SMARTAppLaunch::DiscoverySTU1Group do
     end
     let(:full_capabilities) { capabilities_with_smart(full_extensions) }
 
+    let(:relative_extensions) do
+      [
+        {
+          url: 'authorize',
+          valueUri: 'authorize'
+        },
+        {
+          url: 'introspect',
+          valueUri: '/introspect'
+        },
+        {
+          url: 'manage',
+          valueUri: "#{url}/manage"
+        },
+        {
+          url: 'register',
+          valueUri: "#{url}/register"
+        },
+        {
+          url: 'revoke',
+          valueUri: "#{url}/revoke"
+        },
+        {
+          url: 'token',
+          valueUri: "#{url}/token"
+        }
+      ]
+    end
+    let(:relative_capabilities) { capabilities_with_smart(relative_extensions) }
+
     def capabilities_with_smart(extensions)
       FHIR::CapabilityStatement.new(
         fhirVersion: '4.0.1',
@@ -117,6 +147,16 @@ RSpec.describe SMARTAppLaunch::DiscoverySTU1Group do
 
       result = run(runnable, url: url)
 
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes when all required extensions are present with relative URLs' do
+      stub_request(:get, "#{url}/metadata")
+        .to_return(status: 200, body: relative_capabilities.to_json)
+
+      result = run(runnable, url: url)
+
+      puts result.result_message
       expect(result.result).to eq('pass')
     end
 

--- a/spec/smart_app_launch/url_helpers_spec.rb
+++ b/spec/smart_app_launch/url_helpers_spec.rb
@@ -1,0 +1,80 @@
+require_relative '../../lib/smart_app_launch/url_helpers'
+require_relative '../request_helper'
+
+RSpec.describe SMARTAppLaunch::URLHelpers do
+  # See: https://datatracker.ietf.org/doc/html/rfc1808#section-4
+  # See: https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
+  let(:klass) { Class.new { extend SMARTAppLaunch::URLHelpers } }
+  let(:url) { 'https://example.com/fhir/'}
+  let(:relative_url) { 'bar' }
+  let(:full_url) { 'https://example.com/fhir/bar' }
+
+  let(:base_url) { 'http://a/b/c/d;p?q#f' }
+  let(:examples) {
+    {
+      'g:h' => 'g:h',
+      'g' => 'http://a/b/c/g',
+      './g' => 'http://a/b/c/g',
+      'g/' => 'http://a/b/c/g/',
+      '/g' => 'http://a/g',
+      '//g' => 'http://g',
+      '?y' => 'http://a/b/c/d;p?y',
+      'g?y' => 'http://a/b/c/g?y',
+      'g?y/./x' => 'http://a/b/c/g?y/./x',
+      '#s' => 'http://a/b/c/d;p?q#s',
+      'g#s' => 'http://a/b/c/g#s',
+      'g#s/./x' => 'http://a/b/c/g#s/./x',
+      'g?y#s' => 'http://a/b/c/g?y#s',
+      ';x' => 'http://a/b/c/;x',
+      'g;x' => 'http://a/b/c/g;x',
+      'g;x?y#s' => 'http://a/b/c/g;x?y#s',
+      '.' => 'http://a/b/c/',
+      './' => 'http://a/b/c/',
+      '..' => 'http://a/b/',
+      '../' => 'http://a/b/',
+      '../g' => 'http://a/b/g',
+      '../..' => 'http://a/',
+      '../../' => 'http://a/',
+      '../../g' => 'http://a/g'
+    }
+  }
+
+  it 'passes the normal RFC1808 examples' do
+    # https://datatracker.ietf.org/doc/html/rfc1808#section-5.1
+    examples.each do |embedded, absolute|
+      new_url = klass.make_url_absolute(base_url, embedded)
+      expect(new_url).to eq(absolute)
+    end
+  end
+
+  it 'does not overwrite absolute urls' do
+    new_url = klass.make_url_absolute(url, 'https://foo.org')
+    expect(new_url).to eq('https://foo.org')
+
+    new_url = klass.make_url_absolute(url, 'https://foo.org/')
+    expect(new_url).to eq('https://foo.org/')
+  end
+
+  it 'returns nil when a nil embedded URL is provided' do
+    new_url = klass.make_url_absolute(url, nil)
+    expect(new_url).to eq(nil)
+  end
+
+  it 'returns the base URL when an empty embedded URL is provided' do
+    new_url = klass.make_url_absolute(url, '')
+    expect(new_url).to eq(url)
+  end
+
+  it 'If the embedded URL is preceded by a slash, then the path is not relative' do
+    leading_slash_url = klass.make_url_absolute(url, 'bar')
+    expect(leading_slash_url).to eq('https://example.com/fhir/bar')
+
+    leading_slash_url = klass.make_url_absolute(url, '/bar')
+    expect(leading_slash_url).to eq('https://example.com/bar')
+  end
+
+  it 'handles relative urls with multiple path components' do
+    new_url = klass.make_url_absolute(url, 'bar/baz')
+    expect(new_url).to eq('https://example.com/fhir/bar/baz')
+  end
+end

--- a/spec/smart_app_launch/url_helpers_spec.rb
+++ b/spec/smart_app_launch/url_helpers_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SMARTAppLaunch::URLHelpers do
     expect(new_url).to eq(url)
   end
 
-  it 'If the embedded URL is preceded by a slash, then the path is not relative' do
+  it 'treats embedded URLs starting with a slash as non-relative' do
     leading_slash_url = klass.make_url_absolute(url, 'bar')
     expect(leading_slash_url).to eq('https://example.com/fhir/bar')
 

--- a/spec/smart_app_launch/well_known_endpoint_test_spec.rb
+++ b/spec/smart_app_launch/well_known_endpoint_test_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe SMARTAppLaunch::WellKnownEndpointTest do
     }
   end
 
+  let(:relative_well_known_config) do
+    {
+      'authorization_endpoint' => 'authorize',
+      'token_endpoint' => 'http://foobar.quz/token',
+      'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
+      'registration_endpoint' => '/auth/register',
+      'scopes_supported' =>
+        ['openid', 'profile', 'launch', 'launch/patient', 'patient/*.*', 'user/*.*', 'offline_access'],
+      'response_types_supported' => ['code', 'code id_token', 'id_token', 'refresh_token'],
+      'management_endpoint' => 'user/manage',
+      'introspection_endpoint' => '/introspect',
+      'revocation_endpoint' => 'https://example.com/fhir/user/revoke',
+      'capabilities' =>
+        ['launch-ehr', 'client-public', 'client-confidential-symmetric', 'context-ehr-patient', 'sso-openid-connect'],
+      'issuer' => 'https://example.com',
+      'jwks_uri' => 'https://example.com/.well-known/jwks.json',
+      'grant_types_supported' => ['authorization_code'],
+      'code_challenge_methods_supported' => ['S256']
+    }
+  end
+
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
@@ -48,6 +69,34 @@ RSpec.describe SMARTAppLaunch::WellKnownEndpointTest do
     result = run(runnable, url: url)
 
     expect(result.result).to eq('pass')
+  end
+
+  it 'passes when a valid well-known configuration is received with relative SMART URLs' do
+    stub_request(:get, well_known_url)
+      .to_return(status: 200, body: relative_well_known_config.to_json, headers: { 'Content-Type' => 'application/json' })
+    result = run(runnable, url: url)
+
+    expect(result.result).to eq('pass')
+  end
+
+  it 'converts relative URLs to absolute URLs' do
+    stub_request(:get, well_known_url)
+      .to_return(status: 200, body: relative_well_known_config.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    run(runnable, url: url)
+
+    expected_outputs = {
+      well_known_authorization_url: 'http://example.com/fhir/authorize',
+      well_known_introspection_url: 'http://example.com/introspect',
+      well_known_management_url: 'http://example.com/fhir/user/manage',
+      well_known_registration_url: 'http://example.com/auth/register',
+      well_known_revocation_url: 'https://example.com/fhir/user/revoke',
+      well_known_token_url: 'http://foobar.quz/token'
+    }
+
+    expected_outputs.each do |name, value|
+      expect(session_data_repo.load(test_session_id: test_session.id, name: name)).to eq(value.to_s)
+    end
   end
 
   it 'sends an Accept Header with application/json' do


### PR DESCRIPTION
# Summary

Allows relative SMART URLs in CapabilityStatement and `.well-known/smart-configuration` by turning them into an absolute URL. This PR uses `URI.join` to perform the relative -> absolute expansion. It follows the rules laid out by RFC1808 and RFC 3986.

This means that relative URLs that start with `/` are not considered relative.
e.g.
With a Base URL `http://example.com/fhir`
The relative URL `authorize` becomes  `http://example.com/fhir/authorize`
The relative URL `introspect` becomes  `http://example.com/introspect`

# Testing Guidance

Run the unit tests

`bundle exec rake`

Run the test suite against a configuration endpoint that has relative URLs. A small HTTP server is included below to aid in testing, but feel free to use other means. (Also, if anyone knows a better way I'm all ears!)

- Download [test_server.rb.txt](https://github.com/inferno-framework/smart-app-launch-test-kit/files/9603135/test_server.rb.txt) and remove the `.txt` extension. Put this file in the root of the project directory.
- Run the server with`bundle exec ruby test_server.rb`
- Run Inferno with `ASYNC_JOBS=false bundle exec puma`
- Run the standalone launch test against this server. The server is listening to `http://localhost:4569`, but will accept any path endings (e.g. `http://localhost:4569/fhir`).
- Cancel the tests when you get to the redirect test.

<details>
<summary><h2>Click to Expand Screenshots</h2></summary>

![Screen Shot 2022-09-19 at 8 40 16 PM](https://user-images.githubusercontent.com/41651655/191143413-36b413f0-50f2-4cb9-957d-be4a593dfb16.png)

![Screen Shot 2022-09-19 at 8 40 50 PM](https://user-images.githubusercontent.com/41651655/191143456-67c35ef4-a4cf-44f7-94c9-4182d5a016c5.png)

![Screen Shot 2022-09-19 at 8 41 03 PM](https://user-images.githubusercontent.com/41651655/191143490-5635c2a1-aa75-4075-b810-dff34b01bc2e.png)

![Screen Shot 2022-09-19 at 8 41 13 PM](https://user-images.githubusercontent.com/41651655/191143502-7112f5d9-b880-4f53-8517-79bf7df5b9c5.png)

</details>

# References
- https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/268
- https://jira.hl7.org/browse/FHIR-38645

For the mini-server: ([Ref 1](https://blog.appsignal.com/2016/11/23/ruby-magic-building-a-30-line-http-server-in-ruby.html), [Ref 2](https://dev.to/leandronsp/web-basics-a-simple-http-server-in-ruby-2jj4))