### PR TITLE
FI-1851: Handle refresh without new token

### DIFF
--- a/lib/smart_app_launch/token_refresh_test.rb
+++ b/lib/smart_app_launch/token_refresh_test.rb
@@ -48,7 +48,7 @@ module SMARTAppLaunch
 
       token_response_body = JSON.parse(request.response_body)
       output smart_credentials: {
-               refresh_token: token_response_body['refresh_token'],
+               refresh_token: token_response_body['refresh_token'].presence || refresh_token,
                access_token: token_response_body['access_token'],
                expires_in: token_response_body['expires_in'],
                client_id: client_id,


### PR DESCRIPTION
Include the original refresh token in the smart credentials output when no new refresh token is received (see https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/377).