### PR TITLE
Update launch test description

### DIFF
--- a/lib/smart_app_launch/launch_received_test.rb
+++ b/lib/smart_app_launch/launch_received_test.rb
@@ -2,7 +2,8 @@ module SMARTAppLaunch
   class LaunchReceivedTest < Inferno::Test
     title 'EHR server sends launch parameter'
     description %(
-      Code is a required querystring parameter on the redirect.
+      The `launch` URL parameter associates the app's authorization request with
+      the current EHR session.
     )
     id :smart_launch_received
 


### PR DESCRIPTION
The launch received test had the same description as the code received test, which does not make sense.