### PR TITLE
FI-1954: mention FHIR(r) in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a collection of tests for the [SMART Application Launch Framework
 Implementation Guide](http://hl7.org/fhir/smart-app-launch/index.html) using the
-[Inferno Framework](https://inferno-framework.github.io/inferno-core/).
+[Inferno Framework](https://inferno-framework.github.io/inferno-core/), verifying
+that a server can provide authorization and/or authentication services to client 
+applications accessing HL7® FHIR® APIs.
 
 ## Instructions
 

--- a/lib/smart_app_launch/smart_stu1_suite.rb
+++ b/lib/smart_app_launch/smart_stu1_suite.rb
@@ -34,10 +34,11 @@ module SMARTAppLaunch
     }
 
     description <<~DESCRIPTION
-      The SMART App Launch Test Suite verifies that servers correctly implement
-      the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/1.0.0/).
-      To get started, please first register the Inferno client as a SMART App
-      with the following information:
+    The SMART App Launch Test Suite verifies that systems correctly implement 
+      the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/1.0.0/) 
+      for providing authorization and/or authentication services to client 
+      applications accessing HL7® FHIR® APIs. To get started, please first register 
+      the Inferno client as a SMART App with the following information:
 
       * SMART Launch URI: `#{config.options[:launch_uri]}`
       * OAuth Redirect URI: `#{config.options[:redirect_uri]}`

--- a/lib/smart_app_launch/smart_stu1_suite.rb
+++ b/lib/smart_app_launch/smart_stu1_suite.rb
@@ -34,7 +34,7 @@ module SMARTAppLaunch
     }
 
     description <<~DESCRIPTION
-    The SMART App Launch Test Suite verifies that systems correctly implement 
+      The SMART App Launch Test Suite verifies that systems correctly implement 
       the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/1.0.0/) 
       for providing authorization and/or authentication services to client 
       applications accessing HL7® FHIR® APIs. To get started, please first register 

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -40,11 +40,11 @@ module SMARTAppLaunch
     }
 
     description <<~DESCRIPTION
-    The SMART App Launch Test Suite verifies that systems correctly implement 
-    the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/STU2/) 
-    for providing authorization and/or authentication services to client 
-    applications accessing HL7® FHIR® APIs. To get started, please first register 
-    the Inferno client as a SMART App with the following information:
+      The SMART App Launch Test Suite verifies that systems correctly implement 
+      the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/STU2/) 
+      for providing authorization and/or authentication services to client 
+      applications accessing HL7® FHIR® APIs. To get started, please first register 
+      the Inferno client as a SMART App with the following information:
 
       * SMART Launch URI: `#{config.options[:launch_uri]}`
       * OAuth Redirect URI: `#{config.options[:redirect_uri]}`

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -40,10 +40,11 @@ module SMARTAppLaunch
     }
 
     description <<~DESCRIPTION
-      The SMART App Launch Test Suite verifies that servers correctly implement
-      the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/STU2/).
-      To get started, please first register the Inferno client as a SMART App
-      with the following information:
+    The SMART App Launch Test Suite verifies that systems correctly implement 
+    the [SMART App Launch IG](http://hl7.org/fhir/smart-app-launch/STU2/) 
+    for providing authorization and/or authentication services to client 
+    applications accessing HL7® FHIR® APIs. To get started, please first register 
+    the Inferno client as a SMART App with the following information:
 
       * SMART Launch URI: `#{config.options[:launch_uri]}`
       * OAuth Redirect URI: `#{config.options[:redirect_uri]}`


### PR DESCRIPTION
# Summary

Mention FHIR explicitly in suite descriptions and at the top of the readme so that we can put trademark symbols on.

# Testing Guidance

Launch the Test Kit and check that the description was updated in both STU1 and STU2 suites