### PR TITLE
FI-2031: Remove client auth type input from stu1 token exchange

### DIFF
--- a/spec/smart_app_launch/token_exchange_test_spec.rb
+++ b/spec/smart_app_launch/token_exchange_test_spec.rb
@@ -14,14 +14,12 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
     {
       code: 'CODE',
       smart_token_url: token_url,
-      client_id: 'CLIENT_ID',
-      client_auth_type: 'public'
+      client_id: 'CLIENT_ID'
     }
   end
   let(:confidential_inputs) do
     public_inputs.merge(
-      client_secret: 'CLIENT_SECRET',
-      client_auth_type: 'confidential_symmetric'
+      client_secret: 'CLIENT_SECRET'
     )
   end
 


### PR DESCRIPTION
This branch moves the client auth type from the stu1 token exchange test to the stu2 token exchange test. Before this change, all smart launches would need to provide the client auth type input, even though it was only really necessary for stu2. Now that input will only be available in stu2 launches, so presets for stu1 (including g10 w/SMART stu1) will not need to be changed.

If you point the g10 tests to this branch, you'll be able to run the tests with the reference server preset as normal when using SMART stu1, but if you use SMART stu2, you will see the additional client auth inputs.