### PR TITLE
FI-2080 Initial token introspection tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 JS_HOST=""
+COMPOSE_PROFILES=keycloak

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 INFERNO_HOST=http://localhost:4567
 VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0
+COMPOSE_PROFILES=keycloak

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 
 group :development, :test do
   gem 'debug'
+  gem 'foreman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
       nokogiri (>= 1.11.4)
+    foreman (0.87.2)
     hanami-controller (2.0.0.beta1)
       dry-configurable (~> 0.13, >= 0.13.0)
       hanami-utils (~> 2.0.beta)
@@ -285,6 +286,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 
@@ -292,6 +294,7 @@ DEPENDENCIES
   database_cleaner-sequel (~> 1.8)
   debug
   factory_bot (~> 6.1)
+  foreman
   rack-test (~> 1.1.0)
   rspec (~> 3.10)
   smart_app_launch_test_kit!

--- a/config/keycloak/realm-export.json
+++ b/config/keycloak/realm-export.json
@@ -691,7 +691,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
+      "secret": "lLICFElPPfdcRQGnUcFjqAWexB1T6pqb",
       "redirectUris": [
         "http://host.docker.internal/custom/smart_stu2/redirect",
         "http://localhost/custom/smart_stu2/launch"
@@ -777,50 +777,7 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ],
-      "authorizationSettings": {
-        "allowRemoteResourceManagement": true,
-        "policyEnforcementMode": "ENFORCING",
-        "resources": [
-          {
-            "name": "Default Resource",
-            "type": "urn:inferno_client_confidential:resources:default",
-            "ownerManagedAccess": false,
-            "attributes": {},
-            "_id": "c375ed38-5c8c-474a-93ab-2aea9f491eae",
-            "uris": [
-              "/*"
-            ]
-          }
-        ],
-        "policies": [
-          {
-            "id": "326a7723-bcdf-414d-b146-678db968419b",
-            "name": "Default Policy",
-            "description": "A policy that grants access only for users within this realm",
-            "type": "js",
-            "logic": "POSITIVE",
-            "decisionStrategy": "AFFIRMATIVE",
-            "config": {
-              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
-            }
-          },
-          {
-            "id": "2b6f74e9-a7bb-496b-b957-f91b51dfb08d",
-            "name": "Default Permission",
-            "description": "A permission that applies to the default resource type",
-            "type": "resource",
-            "logic": "POSITIVE",
-            "decisionStrategy": "UNANIMOUS",
-            "config": {
-              "defaultResourceType": "urn:inferno_client_confidential:resources:default",
-              "applyPolicies": "[\"Default Policy\"]"
-            }
-          }
-        ],
-        "scopes": [],
-        "decisionStrategy": "UNANIMOUS"
-      }
+      ]
     },
     {
       "id": "f3db67d2-caa1-418d-9e24-c289cb788f60",

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -28,3 +28,12 @@ services:
     volumes:
       - ./data/redis:/data
     command: redis-server --appendonly yes
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.4
+    container_name: keycloak_auth_server
+    ports:
+      - "8080:8080"
+    environment:
+      - KEYCLOAK_ADMIN=admin 
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -36,4 +36,8 @@ services:
     environment:
       - KEYCLOAK_ADMIN=admin 
       - KEYCLOAK_ADMIN_PASSWORD=admin
-    command: start-dev
+    command: ["start-dev", "--import-realm"]
+    profiles:
+      - keycloak
+    volumes:
+      - ./config/keycloak:/opt/keycloak/data/import

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,7 @@ services:
     extends:
       file: docker-compose.background.yml
       service: redis
+  keycloak:
+    extends:
+      file: docker-compose.background.yml
+      service: keycloak

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -1,0 +1,2347 @@
+{
+  "id": "387b9128-fde7-4ab1-a96b-0c168463e8cd",
+  "realm": "inferno",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 1800,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "e7843f69-cf4e-4c2e-879d-bae23f0bb601",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "387b9128-fde7-4ab1-a96b-0c168463e8cd",
+        "attributes": {}
+      },
+      {
+        "id": "de10b9ce-701d-43bb-8003-057396caa1e1",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "387b9128-fde7-4ab1-a96b-0c168463e8cd",
+        "attributes": {}
+      },
+      {
+        "id": "8a8f9907-1ef7-4278-95b9-03ae9d5344dd",
+        "name": "default-roles-inferno",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "387b9128-fde7-4ab1-a96b-0c168463e8cd",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "inferno_client_public": [],
+      "realm-management": [
+        {
+          "id": "92345b6b-ebc0-46aa-bdb1-495febd97d00",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "55e3c335-368e-459c-8034-e43a5385bfcf",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "6d4742e7-dee5-40b9-a764-f0746f5ea155",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "91124c50-37fa-4974-9b5d-04892d7a2367",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "9e71a1e5-1f3f-4328-ace5-3aff4568b8db",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "5069b6da-c5c6-4676-9006-b0bbaf89605d",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "dca9a286-8b5d-42ca-9db7-3ceb316367de",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "4700f094-48c2-4617-87bd-fb772e0a3484",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "1813dbe7-d353-4a17-a742-69f3f77f7505",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "1655e30e-2771-4f66-a4c8-2c7c294631ab",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "504e67d8-1474-4001-9e91-b563de81fd66",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "b493baea-8ac9-4dee-8563-83cef0bf4bbd",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "6cdb56bd-80a6-4bad-b5cd-f1c291c1e172",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "82d1eac6-a1f9-4f00-a041-38e7ae6cc5bf",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "b1a8d495-27cd-4af9-9e5f-8eca6eacb00c",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "manage-clients",
+                "query-groups",
+                "create-client",
+                "manage-events",
+                "impersonation",
+                "query-realms",
+                "view-clients",
+                "manage-realm",
+                "view-authorization",
+                "manage-users",
+                "manage-authorization",
+                "view-identity-providers",
+                "query-users",
+                "view-users",
+                "query-clients",
+                "view-events",
+                "view-realm",
+                "manage-identity-providers"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "a03f0355-4832-45c5-82c4-627e0efaaa9c",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "4172d5a1-9da8-4d2c-bab1-d8944135d6d4",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "178dcb29-cfec-4323-a861-e02e8ec2b14f",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        },
+        {
+          "id": "f6d35912-847e-4302-bd10-e3717a1c2fcd",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "76a66cbb-7e96-430e-8685-a01a70c6e615",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cbf78b8f-857f-45f9-8a12-87669816c021",
+          "attributes": {}
+        }
+      ],
+      "inferno_client_confidential": [
+        {
+          "id": "d60a7c9e-97bb-40a6-9da2-2d445453e69d",
+          "name": "uma_protection",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2eee8348-82e8-460d-a897-2c502de422f5",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "872ac162-e390-437f-a9e6-73cd07c747b1",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "67e6bb6e-6db9-4901-8ec9-000b090e4457",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "13a5f091-3512-4516-83f1-2ee68ee4f205",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "5069eff9-56d6-4953-b27d-2019d250d3ff",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "2b9eb3ba-2885-4cfc-b039-baa774aca806",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "5484c8a4-04e0-4441-9fb4-16338a29912c",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "4fcfd34d-cabd-4859-86e6-533553201e43",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        },
+        {
+          "id": "05e0c8c0-1e0e-4dcc-9ba3-d28a1c69b2c7",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "8a8f9907-1ef7-4278-95b9-03ae9d5344dd",
+    "name": "default-roles-inferno",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "387b9128-fde7-4ab1-a96b-0c168463e8cd"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppMicrosoftAuthenticatorName",
+    "totpAppGoogleName"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "users": [
+    {
+      "id": "cccc5924-eadc-47b0-8090-ccb6da148eb4",
+      "createdTimestamp": 1696536004430,
+      "username": "service-account-inferno_client_confidential",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "inferno_client_confidential",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-inferno"
+      ],
+      "clientRoles": {
+        "inferno_client_confidential": [
+          "uma_protection"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "0c0a8c14-1363-458d-abd4-c71669fb5705",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/inferno/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/inferno/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "701309f3-5983-467e-92f1-4875593ed09a",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/inferno/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/inferno/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "77a4591b-39a1-4c0b-83fb-ce9a335b6dc8",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "80fcdb94-e199-4a85-a4c7-9d1b1f15c84d",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "cbf78b8f-857f-45f9-8a12-87669816c021",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2eee8348-82e8-460d-a897-2c502de422f5",
+      "clientId": "inferno_client_confidential",
+      "name": "",
+      "description": "Confidential inferno client that uses client credentials grant",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://host.docker.internal/custom/smart_stu2/redirect",
+        "http://localhost/custom/smart_stu2/launch"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1696536004",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "ce3327d8-3d3b-4462-86b5-7f4f9ba36ccf",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7d891e05-9613-4517-b5d6-e6a3c256be81",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "736bd327-26cc-46bd-a994-f4dbc9648815",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:inferno_client_confidential:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "c375ed38-5c8c-474a-93ab-2aea9f491eae",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "326a7723-bcdf-414d-b146-678db968419b",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "2b6f74e9-a7bb-496b-b957-f91b51dfb08d",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:inferno_client_confidential:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "f3db67d2-caa1-418d-9e24-c289cb788f60",
+      "clientId": "inferno_client_public",
+      "name": "",
+      "description": "Inferno application acting as a client, public access (no client credentials grant)",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost/custom/smart_stu2/launch",
+        "http://localhost/custom/smart_stu2/redirect"
+      ],
+      "webOrigins": [
+        "http://localhost"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "417e84f1-89ea-42bd-9f9d-80f8819b03dc",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "049ab8b2-dc67-41b9-b7db-46e2b6273298",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/inferno/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/inferno/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "cd4a4871-f111-4ca8-8803-93bea873c2df",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "f62c8ff5-451f-4afa-8e5d-d1910c037728",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "b4b68c07-bf44-4391-ab02-0dc540fa7ada",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "634c3fb8-d819-493d-b05f-5c50a5edcbd8",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "e1b47e08-4277-4725-a726-d1f0f6dcb6ba",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "4431de67-bff3-47c8-893e-bff70fefd7de",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "462bc430-781d-408f-ad60-802327427b2f",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "179c1d42-8391-4218-808d-de4d1b719aaa",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "744964c7-be09-4020-9d9b-d053be033c9c",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "80c1cb35-272f-490e-895d-2ab73a9a76be",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "727ab852-e6c3-4a74-ba70-cba6d9035f0e",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "f8acd6e1-343d-4f47-93ed-8b1c549fcc57",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "76e89e66-084e-4b41-a2be-001289858121",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "8dc28a7f-9597-4259-988c-5b19fd69c31c",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "dc7672cc-606e-4b5b-842b-fbfc0f72aef4",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "a4870b13-8090-4ce9-8ac6-c8253defa1d6",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5055b5b1-9f91-4fe0-a504-8c013b2df9a6",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ea94aa09-5043-4901-bd72-9a0370d08d0a",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "be0a9110-8e05-4761-8ce2-fbb0175e2423",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "88e9dd11-19fa-4f84-b1a2-74e4d55af819",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "00e8df69-fd0f-4cf4-a405-09a13a45dd4a",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2d9e7e93-5d86-45f8-86a3-ad1abffcdc7f",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f417bbf2-829b-4391-958b-81ef61caa028",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "831f88fe-503e-4676-aa44-7ea3ac206b5e",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2924e113-0936-485c-aa4f-897541d736ea",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "0bc3ae7e-a77c-42ce-93ee-94a2d377615b",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "87790abc-1fdf-46a5-9ad1-3e62ee6538ca",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0200454e-9606-432a-9a94-2cac4a6ee9b0",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "90fb7e22-057b-42b3-b515-b74c2757ead7",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5ec064e6-6763-4aff-8889-93653e10dd54",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "710050a5-ad27-407f-bf07-fb63f4113fd9",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "31862520-1617-483b-a007-735ad717122d",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "31a229af-8af2-4788-ad6d-72571016e338",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "ead6402e-f3af-4cc5-91d7-85617f026233",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e914897e-e084-4605-aa92-4cb9b84ddecd",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "bd2285f1-69f9-44e0-b341-66bfae72aef0",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "0fe5044a-fa8b-448d-9f1c-a334d641224b",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "59295a9c-0c79-4216-bc45-a75593ffd6cd",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "3c283966-e2eb-4bd1-ab26-65fdc7efdba0",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "b5d8248c-94ce-4c4d-a013-b509f4788914",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "1bf47616-9af2-449e-afdd-6058ed847f3c",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "54f16079-7249-45a6-a5bc-3b04423ff562",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0cec291c-829f-4833-9746-7968dd35795e",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "915c13ab-3b1f-410e-885e-49955e81f102",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "42bd2f23-2ce5-4743-aaf5-f5830bce71f8",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "deccf15d-5cf7-4e72-91d5-7da40c1c13a3",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "id": "8c1a41df-d6f0-41d4-a6a2-9b294aca1ed3",
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "97dd0b68-0894-49c7-b92e-64a11ac4d2e1",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "fa9a16b2-0019-4b01-9f7e-d91cff459b88",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "8b3fde50-780c-4abf-9609-2d069a4d9cb2",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "96ec0e16-67de-4c2e-b505-808e96fc71e4",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "9a6f9430-6eb1-475f-be2f-a9b580e10425",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e5b30c4b-23f1-451c-b41b-a642e374b5dd",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6ccd8a62-61f2-456e-8170-a6ffc0b77817",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2905482c-374b-41ad-b77b-608b2c5f71b0",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cad4ece0-1a07-40cc-9c30-9d9eb057c5e1",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f86cab5f-7ae1-4969-9cef-4059e9c45a34",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8a28c609-ec83-4a3a-bd4c-9e7526533fa9",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "45156991-4e17-4142-9c1b-84a6c9a2f61b",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "efd43231-c1b9-436d-a761-5d6f8ef5ba65",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8d8f7d88-07ab-45be-94c9-c994a0768ae3",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "220e8b08-c2a0-4807-87c8-50e003b3ff42",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "842ee147-5390-49ea-a66e-d80434877aa3",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8e0ac28f-84f3-4553-8f61-f5fb610d1153",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "64cf476a-0abb-4b53-a3bb-98e12872fdfd",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3cc58430-eb26-4483-9d83-1794e3509f2e",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "15d1a2d1-0f06-46e0-be84-94d627fc67ad",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c1ae7984-7bdf-4e95-8eb9-b721ec2f3bab",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "13ea7151-6639-4175-9f94-835ee62277ad",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "c5a3ac34-f0b2-4933-bacd-ad5366d97637",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "ce33735d-5416-4779-baa6-34b9840b6fe6",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "actionTokenGeneratedByUserLifespan-execute-actions": "",
+    "actionTokenGeneratedByUserLifespan-verify-email": "",
+    "clientOfflineSessionIdleTimeout": "0",
+    "actionTokenGeneratedByUserLifespan-reset-credentials": "",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "actionTokenGeneratedByUserLifespan-idp-verify-account-via-email": "",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "shortVerificationUri": ""
+  },
+  "keycloakVersion": "22.0.4",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -7,6 +7,7 @@ require_relative 'standalone_launch_group_stu2'
 require_relative 'ehr_launch_group_stu2'
 require_relative 'openid_connect_group'
 require_relative 'token_refresh_group'
+require_relative 'token_introspection'
 
 module SMARTAppLaunch
   class SMARTSTU2Suite < Inferno::TestSuite
@@ -203,6 +204,21 @@ module SMARTAppLaunch
                 smart_credentials: { name: :ehr_smart_credentials }
               }
             }
+    end
+  
+    # TBD - group token introspection? 
+    group do
+      title 'Token Introspection'
+      id :smart_token_introspection
+
+      input_instructions <<~INSTRUCTIONS
+        TODO: Instructions for token introspection go here!
+      INSTRUCTIONS
+      
+      group from: :token_introspection_test_group
+
+      run_as_group
+
     end
   end
 end

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -4,22 +4,52 @@ module SMARTAppLaunch
     description %(TODO)
     id :token_introspection_test_group
 
-    def get_access_token()
-      # todo
+    DEFAULT_INTR_BASE_URL = 'http://keycloak_auth_server:8080/realms/inferno'
+    DEFAULT_TOKEN_ENDPOINT = 'protocol/openid-connect/token'
+    DEFAULT_INTR_ENDPOINT = 'protocol/openid-connect/token/introspect'
+    DEFAULT_CLIENT_ID = 'inferno_client_confidential'
+    DEFAULT_CLIENT_SECRET = 'lLICFElPPfdcRQGnUcFjqAWexB1T6pqb'
+
+    input :token_introspection_base_url, default: DEFAULT_INTR_BASE_URL
+    input :token_endpoint, default: DEFAULT_TOKEN_ENDPOINT
+    input :token_introspection_endpoint, default: DEFAULT_INTR_ENDPOINT
+
+    http_client do
+      url :token_introspection_base_url
+    end
+
+    def add_credentials(headers, body, client_id, client_secret)
+      if client_secret.blank?
+        body += "#{:client_id}=#{client_id}"
+      else
+        client_credentials = "#{client_id}:#{client_secret}"
+        headers['Authorization'] = "Basic #{Base64.strict_encode64(client_credentials)}"
+      end
+      return headers, body
     end
 
     test do
       title 'Token introspection endpoint returns correct response for valid token'
-      input :token_introspection_base_url, default: 'http://keycloak_auth_server:8080/realms/inferno'
-      input :token_introspection_endpoint, default: 'http://keycloak_auth_server:8080/realms/inferno/protocol/openid-connect/token/introspect'
-      input :client_id, default: 'inferno_client_confidential'
-      input :client_secret, optional: true, default: 'lLICFElPPfdcRQGnUcFjqAWexB1T6pqb'
-      input :access_token
+      input :client_id, default: DEFAULT_CLIENT_ID
+      input :client_secret, optional: true, default: DEFAULT_CLIENT_SECRET
+      input :openid_scope, 
+            title: 'Include "scope=openid" field',
+                type: 'radio',
+                default: 'true',
+                options: {
+                  list_options: [
+                    {
+                      label: 'Yes',
+                      value: 'true'
+                    },
+                    {
+                      label: 'No',
+                      value: 'false'
+                    }
+                  ]
+                }
+      output :access_token_response
       output :access_token_payload
-
-      http_client do
-        url :token_introspection_base_url
-      end
 
       def test_content_fields(field_name, intr_val, access_val)
         error_msg = "Failure: expected introspection response value for '#{field_name}', #{intr_val}, to match corresponding value in original access token, #{access_val}"
@@ -27,6 +57,19 @@ module SMARTAppLaunch
       end 
 
       run do
+        tok_req_headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
+        tok_req_body = "grant_type=client_credentials"
+        if openid_scope == 'true'
+          tok_req_body+="&scope=openid"
+        end
+        tok_req_headers, tok_req_body = add_credentials(tok_req_headers, tok_req_body, client_id, client_secret)
+        post(token_endpoint, body: tok_req_body, headers: tok_req_headers)
+        assert_response_status(200)
+        assert_valid_json(request.response_body)
+        output access_token_response: JSON.parse(request.response_body)
+
+        access_token = access_token_response['access_token']
+        
         begin
           access_token_payload, access_token_header =
             JWT.decode(
@@ -41,9 +84,7 @@ module SMARTAppLaunch
 
         headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         body = "token=#{access_token}"
-        unless client_secret.blank?
-          body += "&client_id=#{client_id}&client_secret=#{client_secret}&scope=openid"
-        end
+        headers, body = add_credentials(headers, body, client_id, client_secret)
 
         post(token_introspection_endpoint, body: body, headers: headers)
 
@@ -61,9 +102,13 @@ module SMARTAppLaunch
 
         # conditional fields based on access token
         if access_token_payload.has_key?('id_token')
-          puts 'test for id_token fields'
-        else
-          puts 'id_token field not found in access token'
+          # decode token
+          id_token_payload, id_token_header = JWT.decode(access_token_payload['id_token'], nil, false)
+          # check for introspection response iss to match id token iss
+          test_content_fields('iss', introspection_response_body['iss'], id_token_payload['iss'])
+          # check for introspection response sub to match id token sub
+          test_content_fields('sub', introspection_response_body['sub'], id_token_payload['sub'])
+          # create warning/info for fhir user - should be a field in introspection response if id_token in access token
         end
       end
     end

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -4,15 +4,18 @@ module SMARTAppLaunch
     description %(TODO)
     id :token_introspection_test_group
 
+    def get_access_token()
+      # todo
+    end
 
     test do
       title 'Token introspection endpoint returns correct response for valid token'
-      input :token_introspection_base_url,
-            :token_introspection_endpoint,
-            :client_id
-      input :client_secret, optional: true
+      input :token_introspection_base_url, default: 'http://keycloak_auth_server:8080/realms/inferno'
+      input :token_introspection_endpoint, default: 'http://keycloak_auth_server:8080/realms/inferno/protocol/openid-connect/token/introspect'
+      input :client_id, default: 'inferno_client_confidential'
+      input :client_secret, optional: true, default: 'lLICFElPPfdcRQGnUcFjqAWexB1T6pqb'
       input :access_token
-      output :token_introspection_url
+      output :access_token_payload
 
       http_client do
         url :token_introspection_base_url
@@ -31,7 +34,7 @@ module SMARTAppLaunch
               nil,
               false
             )
-            # puts "Access token payload = #{payload}}"
+            output access_token_payload: access_token_payload
         rescue StandardError => e
           assert false, "Access token is not a properly constructed JWT: #{e.message}"
         end
@@ -39,43 +42,52 @@ module SMARTAppLaunch
         headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         body = "token=#{access_token}"
         unless client_secret.blank?
-          body += "&client_id=#{client_id}&client_secret=#{client_secret}"
+          body += "&client_id=#{client_id}&client_secret=#{client_secret}&scope=openid"
         end
-        puts 'Body = ' + body
+
         post(token_introspection_endpoint, body: body, headers: headers)
+
         assert_response_status(200)
         assert_valid_json(request.response_body)
 
-        # check contents
         introspection_response_body = JSON.parse(request.response_body)
 
+        # required fields for all
         assert introspection_response_body['active'] == true, "Failure: expected introspection response for 'active' to be true for valid token"
         test_content_fields('client_id', introspection_response_body['client_id'], access_token_payload['client_id'])
+        # scope test should also account for condtional inclusion of launch context parameter(s), as they would be part of scope
         test_content_fields('scope', introspection_response_body['scope'], access_token_payload['scope'])
         test_content_fields('exp', introspection_response_body['exp'], access_token_payload['exp'])
+
+        # conditional fields based on access token
+        if access_token_payload.has_key?('id_token')
+          puts 'test for id_token fields'
+        else
+          puts 'id_token field not found in access token'
+        end
       end
     end
 
-    test do 
-      title 'Token introspection endpoint returns correct response for invalid token'
-      # TODO fix duplicated code
-      input :token_introspection_base_url,
-            :token_introspection_endpoint,
-            :client_id
-      input :client_secret, optional: true
-      input :access_token
-      output :token_introspection_url
+    # test do 
+    #   title 'Token introspection endpoint returns correct response for invalid token'
+    #   # TODO fix duplicated code
+    #   input :token_introspection_base_url,
+    #         :token_introspection_endpoint,
+    #         :client_id
+    #   input :client_secret, optional: true
+    #   input :access_token
+    #   output :token_introspection_url
 
-      http_client do
-        url :token_introspection_base_url
-      end
+    #   http_client do
+    #     url :token_introspection_base_url
+    #   end
 
-      run do
-        headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
-        body = "token=#{'fake_token_value'}"
-        post(token_introspection_endpoint, body: body, headers: headers)
-        assert_response_status(401)
-      end
-    end
+    #   run do
+    #     headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
+    #     body = "token=#{'fake_token_value'}"
+    #     post(token_introspection_endpoint, body: body, headers: headers)
+    #     assert_response_status(401)
+    #   end
+    # end
   end
 end

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -6,7 +6,6 @@ module SMARTAppLaunch
 
     test do
       title 'Token introspection endpoint returns correct response for valid token'
-      # base url is really just auth server base url I believe
       input :token_introspection_base_url,
             :token_introspection_endpoint,
             :client_id
@@ -19,6 +18,18 @@ module SMARTAppLaunch
       end
 
       run do
+        begin
+          payload, header =
+            JWT.decode(
+              standalone_access_token,
+              nil,
+              false
+            )
+            # puts "Access token payload = #{payload}}"
+        rescue StandardError => e
+          assert false, "Access token is not a properly constructed JWT: #{e.message}"
+        end
+
         headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         body = "token=#{standalone_access_token}"
         unless client_secret.blank?
@@ -27,6 +38,19 @@ module SMARTAppLaunch
         puts 'Body = ' + body
         post(token_introspection_endpoint, body: body, headers: headers)
         assert_response_status(200)
+        assert_valid_json(request.response_body)
+
+        # check contents
+        introspection_response_body = JSON.parse(request.response_body)
+        active_value = introspection_response_body['active']
+        client_id_value = introspection_response_body['client_id']
+        scope_value = introspection_response_body['scope']
+        exp_value = introspection_response_body['exp']
+
+        assert active_value == true, 'Failure: active not set to true for valid token'
+        assert client_id_value == payload['client_id'], 'Failure: client_id field does not match between introspection response and original access token'
+        assert scope_value == payload['scope'], 'Failure: scope field does not match between introspection response and original access token'
+        assert exp_value == payload['exp'], 'Failure: exp field does not match between introspection response and original access token'
       end
     end
 

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -21,6 +21,10 @@ module SMARTAppLaunch
       run do
         headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         body = "token=#{standalone_access_token}"
+        unless client_secret.blank?
+          body += "&client_id=#{client_id}&client_secret=#{client_secret}"
+        end
+        puts 'Body = ' + body
         post(token_introspection_endpoint, body: body, headers: headers)
         assert_response_status(200)
       end

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -6,6 +6,7 @@ module SMARTAppLaunch
 
     test do
       title 'Token introspection endpoint returns correct response for valid token'
+      # base url is really just auth server base url I believe
       input :token_introspection_base_url,
             :token_introspection_endpoint,
             :client_id
@@ -27,6 +28,24 @@ module SMARTAppLaunch
 
     test do 
       title 'Token introspection endpoint returns correct response for invalid token'
+      # TODO fix duplicated code
+      input :token_introspection_base_url,
+            :token_introspection_endpoint,
+            :client_id
+      input :client_secret, optional: true
+      input :standalone_access_token
+      output :token_introspection_url
+
+      http_client do
+        url :token_introspection_base_url
+      end
+
+      run do
+        headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
+        body = "token=#{'fake_token_value'}"
+        post(token_introspection_endpoint, body: body, headers: headers)
+        assert_response_status(401)
+      end
     end
   end
 end

--- a/lib/smart_app_launch/token_introspection.rb
+++ b/lib/smart_app_launch/token_introspection.rb
@@ -1,0 +1,32 @@
+module SMARTAppLaunch
+  class TokenIntrospectionTestGroup < Inferno::TestGroup
+    title 'Token Introspection Group'
+    description %(TODO)
+    id :token_introspection_test_group
+
+    test do
+      title 'Token introspection endpoint returns correct response for valid token'
+      input :token_introspection_base_url,
+            :token_introspection_endpoint,
+            :client_id
+      input :client_secret, optional: true
+      input :standalone_access_token
+      output :token_introspection_url
+
+      http_client do
+        url :token_introspection_base_url
+      end
+
+      run do
+        headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
+        body = "token=#{standalone_access_token}"
+        post(token_introspection_endpoint, body: body, headers: headers)
+        assert_response_status(200)
+      end
+    end
+
+    test do 
+      title 'Token introspection endpoint returns correct response for invalid token'
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This PR presents an opportunity for feedback on a first pass at implementing token introspection tests per JIRA ticket [FI-2080](https://oncprojectracking.healthit.gov/support/browse/FI-2080), based on the [SMART App Launch Token Introspection IG](https://hl7.org/fhir/smart-app-launch/token-introspection.html).  

Currently, these tests are not yet ready for release.  I outline the issues below as well as a recommendation on how to resolve them.  Most of these issues results from having an imperfect reference against which to develop and validate the tests.  Specifically, the existing [Inferno Reference Server](https://github.com/inferno-framework/inferno-reference-server/tree/main) can act as a FHIR server but does not have a real authorization server with token introspection capabilities; in contrast, the the Keycloak instance used in this test kit has verified token introspection capabilities but is not able to provide FHIR resource server capabilities.  The integration of both capabilities is needed to thoroughly validate these tests.    

## Issues 
* **The code as-is still reflects a development environment**, including Docker configuration for a reference authorization server (Keycloak) and default test input parameters for that reference authZ server that facilitate the test development process.  
     * To resolve: these features can stay as they are until the rest of the test kit is ready for release, at which point they could be removed.  To provide a reference authorization server in the long-term, the Inferno reference server could be extended with a shallow, mocked token introspection module or, for a "real" implementation, Keycloak could be integrated as the authorization server for all of the reference server's OAuth/OIDC processes.  
     
* **The active token test does not properly test for SMART Launch Context parameters**.  To do so, the test needs to identify the launch context parameters, if any, that are present in the original access token response per [SMART App Launch Scopes and Launch Context](https://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) to ensure they are also present in the token introspection response.  However, the launch parameters that can be returned in an access token response are not predefined values and are not part of a labeled list or array.  As a result, it is unclear how they can be identified in a generalized manner.  
     * To resolve: better understand how these parameters can be identified and coded into the test kit.

* **Obtaining an access token to provide in the token introspection request is still flawed**.  The access token received from the reference server in the SMART App Standalone Launch is not a valid JWT and therefore cannot validate the tests.  Furthermore, the test requires access to the contents of the entire access token _response_ (instead of just the access token itself), meaning the user cannot provide a lone access token (obtained through other means) as input.  Currently, the test has an option to initiate a new access token request but assumes a specific request format that should instead be configurable.
     * To resolve: if new access token request is selected, users input all variable aspects of the request header and body

* **Authorization to access the introspection endpoint is not yet accounted for by tests**.  Similar to the access token request issues, the current implementation of the token introspection request assumes a specific authorization strategy to the token endpoint.  
     * To resolve: first, more research is needed to understand the myriad of valid ways that introspection endpoint authorization can be achieved.  From there, provide users more configuration options to input.  
