### PR TITLE
Fi 2251 input output reorg

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
 JS_HOST=""
-COMPOSE_PROFILES=keycloak

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
 INFERNO_HOST=http://localhost:4567
 VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0
-COMPOSE_PROFILES=keycloak

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/smart_app_launch/app_redirect_test_stu2.rb
+++ b/lib/smart_app_launch/app_redirect_test_stu2.rb
@@ -16,7 +16,7 @@ module SMARTAppLaunch
     )
 
     input :authorization_method,
-          title: 'Authorization Method',
+          title: 'Authorization Request Method',
           type: 'radio',
           default: 'get',
           options: {

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -9,6 +9,7 @@ require_relative 'openid_connect_group'
 require_relative 'token_refresh_group'
 require_relative 'token_introspection_request_group'
 require_relative 'token_introspection_response_group'
+require_relative 'token_introspection_access_token_group'
 
 module SMARTAppLaunch
   class SMARTSTU2Suite < Inferno::TestSuite
@@ -248,7 +249,7 @@ module SMARTAppLaunch
         token introspection endpoint.
       
       )
-      
+      group from: :token_introspection_access_token_group
       group from: :token_introspection_request_group
       group from: :token_introspection_response_group
 

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -219,7 +219,7 @@ module SMARTAppLaunch
         [SMART App Launch STU 2.1 Implementation Guide Section on Token Introspection](https://hl7.org/fhir/smart-app-launch/token-introspection.html)
         states that "SMART on FHIR EHRs SHOULD support token introspection, which allows a broader ecosystem of resource servers
         to leverage authorization decisions managed by a single authorization server."
-  
+ 
         # Test Methodology
 
         In these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -240,9 +240,9 @@ module SMARTAppLaunch
 
         If needed, however, testers can:
         
-        a. Provide a different active access token to be introspected in Token Introspection Request tests.  However, the
+        1. Provide a different active access token to be introspected in Token Introspection Request tests.  However, the
         tester will need to manually input the access token response parameters for the Token Introspection Response tests. 
-        b. Skip the Token Introspection Request tests altogether and manually run the required access token AND introspection
+        2. Skip the Token Introspection Request tests altogether and manually run the required access token AND introspection
         requests out-of-band to complete the Token Introspection Response tests.  Given the extent of manual steps
         and inputs required, we recommend this option only if it is not possible for the Inferno client to access the
         token introspection endpoint.

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -231,18 +231,18 @@ module SMARTAppLaunch
         the token introspection endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
         broken up into two groups that can be run independently:
 
-        1. Token Introspection Request group - completes the introspection requests
-        2. Token Introspection Response group - validates the contents of the introspection responses
+        1. Issue Token Introspection Request group - completes the introspection requests
+        2. Validate Token Introspection Response group - validates the contents of the introspection responses
 
-        For ease of testing it is highly recommended to run the Token Introspection Request group after already completing the 
+        For ease of testing it is highly recommended to run the Issue Token Introspection Request group after already completing the 
         Standalone Launch tests, as Inferno will by default seek to introspect the access token received during those tests.
-        If this option is used, the Token Introspection Response test inputs will also auto-fill.
+        If this option is used, the Validate Token Introspection Response test inputs will also auto-fill.
 
         If needed, however, testers can:
         
         1. Provide a different active access token to be introspected in Token Introspection Request tests.  However, the
         tester will need to manually input the access token response parameters for the Token Introspection Response tests. 
-        2. Skip the Token Introspection Request tests altogether and manually run the required access token AND introspection
+        2. Skip the Issue Token Introspection Request tests altogether and manually run the required access token AND introspection
         requests out-of-band to complete the Token Introspection Response tests.  Given the extent of manual steps
         and inputs required, we recommend this option only if it is not possible for the Inferno client to access the
         token introspection endpoint.
@@ -251,6 +251,10 @@ module SMARTAppLaunch
       
       group from: :token_introspection_request_group
       group from: :token_introspection_response_group
+
+      input_order :well_known_introspection_url, :standalone_access_token, :standalone_client_id, :standalone_expires_in,
+                  :standalone_received_scopes, :standalone_id_token, :standalone_patient_id, :standalone_encounter_id,
+                  :introspection_client_id, :introspection_client_secret, :custom_auth_method, :custom_authorization_header
 
     end
   end

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -256,6 +256,17 @@ module SMARTAppLaunch
                   :standalone_received_scopes, :standalone_id_token, :standalone_patient_id, :standalone_encounter_id,
                   :introspection_client_id, :introspection_client_secret, :custom_auth_method, :custom_authorization_header
 
+      input_instructions %(
+        Executing tests at this level will run both the Issue Introspection Request group and the Validate Introspection
+        Response group.  The HTTP response bodies from the Issue Request group will automatically be sent as inputs to the 
+        Validate Response group.
+
+        The Validate Response test for an active token will compare fields and/or values from the introspection response
+        to those from the access token response that provided the token being introspected.  These fields are labeled
+        "Access Token Response" and will need to be manaully input unless an access token from the Standalone Launch 
+        tests are being used. 
+      )
+
     end
   end
 end

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -221,14 +221,14 @@ module SMARTAppLaunch
         to leverage authorization decisions managed by a single authorization server."
   
         # Test Methodology
-        
+
         In these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
         token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  
 
         Ideally, Inferno should be registered with the authorization server as an authorized resource server
         capable of accessing the token introspection endpoint through client credentials, per the SMART IG recommendations.  
         However, the SMART IG only formally REQUIRES "some form of authorization" to access
-        the token endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
+        the token introspection endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
         broken up into two groups that can be run independently:
 
         1. Token Introspection Request group - completes the introspection requests
@@ -245,13 +245,9 @@ module SMARTAppLaunch
         b. Skip the Token Introspection Request tests altogether and manually run the required access token AND introspection
         requests out-of-band to complete the Token Introspection Response tests.  Given the extent of manual steps
         and inputs required, we recommend this option only if it is not possible for the Inferno client to access the
-        token introspection.
+        token introspection endpoint.
       
       )
-
-      input_instructions <<~INSTRUCTIONS
-        TODO: Instructions for token introspection go here!
-      INSTRUCTIONS
       
       group from: :token_introspection_request_group
       group from: :token_introspection_response_group

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -213,6 +213,7 @@ module SMARTAppLaunch
       id :smart_token_introspection
       description %(
         # Background
+
         OAuth 2.0 Token introspection, as described in [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662), allows
         an authorized resource server to query an OAuth 2.0 authorization server for metadata on a token.  The
         [SMART App Launch STU 2.1 Implementation Guide Section on Token Introspection](https://hl7.org/fhir/smart-app-launch/token-introspection.html)
@@ -220,21 +221,32 @@ module SMARTAppLaunch
         to leverage authorization decisions managed by a single authorization server."
   
         # Test Methodology
-        For these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
-        token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  By default, 
-        Inferno will aim to introspect the access token from the Standalone Launch tests, but this can be changed with the test inputs. 
         
+        In these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
+        token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  
+
         Ideally, Inferno should be registered with the authorization server as an authorized resource server
         capable of accessing the token introspection endpoint through client credentials, per the SMART IG recommendations.  
         However, the SMART IG only formally REQUIRES "some form of authorization" to access
         the token endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
-        broken up into two groups that can be run indepndently:
+        broken up into two groups that can be run independently:
 
-        1. Tests that complete the introspection request(s)
-        2. Tests that validate the contents of the introspection response(s)
+        1. Token Introspection Request group - completes the introspection requests
+        2. Token Introspection Response group - validates the contents of the introspection responses
 
-        If needed, the introspection request group can be run out of band from the introspection respone validation group
-        to accommodate non-standard authorization approaches to secure the token endpoint.  
+        For ease of testing it is highly recommended to run the Token Introspection Request group after already completing the 
+        Standalone Launch tests, as Inferno will by default seek to introspect the access token received during those tests.
+        If this option is used, the Token Introspection Response test inputs will also auto-fill.
+
+        If needed, however, testers can:
+        
+        a. Provide a different active access token to be introspected in Token Introspection Request tests.  However, the
+        tester will need to manually input the access token response parameters for the Token Introspection Response tests. 
+        b. Skip the Token Introspection Request tests altogether and manually run the required access token AND introspection
+        requests out-of-band to complete the Token Introspection Response tests.  Given the extent of manual steps
+        and inputs required, we recommend this option only if it is not possible for the Inferno client to access the
+        token introspection.
+      
       )
 
       input_instructions <<~INSTRUCTIONS

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -7,7 +7,8 @@ require_relative 'standalone_launch_group_stu2'
 require_relative 'ehr_launch_group_stu2'
 require_relative 'openid_connect_group'
 require_relative 'token_refresh_group'
-require_relative 'token_introspection'
+require_relative 'token_introspection_request_group'
+require_relative 'token_introspection_response_group'
 
 module SMARTAppLaunch
   class SMARTSTU2Suite < Inferno::TestSuite
@@ -210,14 +211,38 @@ module SMARTAppLaunch
     group do
       title 'Token Introspection'
       id :smart_token_introspection
+      description %(
+        # Background
+        OAuth 2.0 Token introspection, as described in [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662), allows
+        an authorized resource server to query an OAuth 2.0 authorization server for metadata on a token.  The
+        [SMART App Launch STU 2.1 Implementation Guide Section on Token Introspection](https://hl7.org/fhir/smart-app-launch/token-introspection.html)
+        states that "SMART on FHIR EHRs SHOULD support token introspection, which allows a broader ecosystem of resource servers
+        to leverage authorization decisions managed by a single authorization server."
+  
+        # Test Methodology
+        For these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
+        token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  By default, 
+        Inferno will aim to introspect the access token from the Standalone Launch tests, but this can be changed with the test inputs. 
+        
+        Ideally, Inferno should be registered with the authorization server as an authorized resource server
+        capable of accessing the token introspection endpoint through client credentials, per the SMART IG recommendations.  
+        However, the SMART IG only formally REQUIRES "some form of authorization" to access
+        the token endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
+        broken up into two groups that can be run indepndently:
+
+        1. Tests that complete the introspection request(s)
+        2. Tests that validate the contents of the introspection response(s)
+
+        If needed, the introspection request group can be run out of band from the introspection respone validation group
+        to accommodate non-standard authorization approaches to secure the token endpoint.  
+      )
 
       input_instructions <<~INSTRUCTIONS
         TODO: Instructions for token introspection go here!
       INSTRUCTIONS
       
-      group from: :token_introspection_test_group
-
-      run_as_group
+      group from: :token_introspection_request_group
+      group from: :token_introspection_response_group
 
     end
   end

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -220,52 +220,52 @@ module SMARTAppLaunch
         [SMART App Launch STU 2.1 Implementation Guide Section on Token Introspection](https://hl7.org/fhir/smart-app-launch/token-introspection.html)
         states that "SMART on FHIR EHRs SHOULD support token introspection, which allows a broader ecosystem of resource servers
         to leverage authorization decisions managed by a single authorization server."
- 
+
         # Test Methodology
 
         In these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
         token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  
-
         Ideally, Inferno should be registered with the authorization server as an authorized resource server
         capable of accessing the token introspection endpoint through client credentials, per the SMART IG recommendations.  
         However, the SMART IG only formally REQUIRES "some form of authorization" to access
-        the token introspection endpoint and does specifiy any one specific approach.  As such, the token introspection tests are 
-        broken up into two groups that can be run independently:
+        the token introspection endpoint and does not specifiy any one specific approach.  As such, the token introspection tests are 
+        broken up into three groups that each complete a discrete step in the token introspection process:
 
-        1. Issue Token Introspection Request group - completes the introspection requests
-        2. Validate Token Introspection Response group - validates the contents of the introspection responses
+        1. **Request Access Token Group** - optional but recommended, repeats a subset of Standalone Launch tests 
+          in order to receive a new access token with an authorization code grant.  If skipped, testers will need to
+            obtain an access token out-of-band and manually provide values from the access token response as inputs to
+            the Validate Token Response group.  
+        2. **Issue Token Introspection Request Group** - optional but recommended, completes the introspection requests.  
+        If skipped, testers will need to complete an introspection request out-of-band and manually provide the introspection
+        responses as inputs to the Validate Token Response group. 
+        3. **Validate Token Introspection Response Group** - required, validates the contents of the introspection responses. 
 
-        For ease of testing it is highly recommended to run the Issue Token Introspection Request group after already completing the 
-        Standalone Launch tests, as Inferno will by default seek to introspect the access token received during those tests.
-        If this option is used, the Validate Token Introspection Response test inputs will also auto-fill.
-
-        If needed, however, testers can:
+        Running all three test groups in order is the simplest and is highly recommended if the environment under test
+        can support it, as outputs from one group will feed the inputs of the next group. However, test groups can be run
+          independently if needed. 
         
-        1. Provide a different active access token to be introspected in Token Introspection Request tests.  However, the
-        tester will need to manually input the access token response parameters for the Token Introspection Response tests. 
-        2. Skip the Issue Token Introspection Request tests altogether and manually run the required access token AND introspection
-        requests out-of-band to complete the Token Introspection Response tests.  Given the extent of manual steps
-        and inputs required, we recommend this option only if it is not possible for the Inferno client to access the
-        token introspection endpoint.
-      
+        See the individual test groups for more details and guidance. 
       )
       group from: :token_introspection_access_token_group
       group from: :token_introspection_request_group
       group from: :token_introspection_response_group
 
-      input_order :well_known_introspection_url, :standalone_access_token, :standalone_client_id, :standalone_expires_in,
-                  :standalone_received_scopes, :standalone_id_token, :standalone_patient_id, :standalone_encounter_id,
-                  :introspection_client_id, :introspection_client_secret, :custom_auth_method, :custom_authorization_header
+      input_order :well_known_introspection_url, :custom_authorization_header, :optional_introspection_request_params,
+                  :url, :client_id, :client_secret, :requested_scopes, :smart_authorization_url, :authorization_method,
+                  :use_pkce, :pkce_code_challenge_method
 
       input_instructions %(
-        Executing tests at this level will run both the Issue Introspection Request group and the Validate Introspection
-        Response group.  The HTTP response bodies from the Issue Request group will automatically be sent as inputs to the 
-        Validate Response group.
+        Executing tests at this level will run all three Token Introspection groups back-to-back.  If test groups need
+        to be run independently, exit this window and select a specific test group instead.   
+      
+        Some inputs are re-used from the Standalone Launch tests to request a new access token for Token
+        Introspection.  If Standalone Launch tests were successfully executed, these inputs will auto-populate.
 
-        The Validate Response test for an active token will compare fields and/or values from the introspection response
-        to those from the access token response that provided the token being introspected.  These fields are labeled
-        "Access Token Response" and will need to be manaully input unless an access token from the Standalone Launch 
-        tests are being used. 
+        If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
+        [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
+        approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
+        server to complete the introspection request.  All parameter values for both the header and the body must be input
+        URI-encoded.
       )
 
     end

--- a/lib/smart_app_launch/token_exchange_test.rb
+++ b/lib/smart_app_launch/token_exchange_test.rb
@@ -33,6 +33,7 @@ module SMARTAppLaunch
     input :pkce_code_verifier, optional: true
     output :token_retrieval_time
     output :smart_credentials
+    output :token_response
     uses_request :redirect
     makes_request :token
 
@@ -70,6 +71,8 @@ module SMARTAppLaunch
 
       output token_retrieval_time: Time.now.iso8601
 
+      output token_response: request.response_body
+
       token_response_body = JSON.parse(request.response_body)
       output smart_credentials: {
                refresh_token: token_response_body['refresh_token'],
@@ -80,6 +83,7 @@ module SMARTAppLaunch
                token_retrieval_time: token_retrieval_time,
                token_url: smart_token_url
              }.to_json
+      
     end
   end
 end

--- a/lib/smart_app_launch/token_exchange_test.rb
+++ b/lib/smart_app_launch/token_exchange_test.rb
@@ -33,7 +33,6 @@ module SMARTAppLaunch
     input :pkce_code_verifier, optional: true
     output :token_retrieval_time
     output :smart_credentials
-    output :token_response
     uses_request :redirect
     makes_request :token
 
@@ -71,9 +70,9 @@ module SMARTAppLaunch
 
       output token_retrieval_time: Time.now.iso8601
 
-      output token_response: request.response_body
-
       token_response_body = JSON.parse(request.response_body)
+
+
       output smart_credentials: {
                refresh_token: token_response_body['refresh_token'],
                access_token: token_response_body['access_token'],

--- a/lib/smart_app_launch/token_introspection_access_token_group.rb
+++ b/lib/smart_app_launch/token_introspection_access_token_group.rb
@@ -1,0 +1,12 @@
+require_relative 'standalone_launch_group_stu2'
+
+module SMARTAppLaunch
+  class TokenIntrospectionAccessTokenGroup < Inferno::TestGroup
+    title 'Receive Access Token to Introspect'
+    run_as_group
+
+    id :token_introspection_access_token_group
+    
+    group from: :smart_standalone_launch_stu2
+  end
+end

--- a/lib/smart_app_launch/token_introspection_access_token_group.rb
+++ b/lib/smart_app_launch/token_introspection_access_token_group.rb
@@ -2,10 +2,20 @@ require_relative 'standalone_launch_group_stu2'
 
 module SMARTAppLaunch
   class TokenIntrospectionAccessTokenGroup < Inferno::TestGroup
-    title 'Receive Access Token to Introspect'
+    title 'Request New Access Token to Introspect'
     run_as_group
 
     id :token_introspection_access_token_group
+
+    description %(
+      These tests are repeated from the Standalone Launch tests in order to receive a new, active access token that
+      will be provided for token introspection. This test group may be skipped if the tester can obtain an access token
+      __and__ the contents of the access token response body by some other means.  
+    )
+    
+    input_instructions %(
+      Complete the Standalone Launch test group to auto-populate the inputs.  
+    )
     
     group from: :smart_standalone_launch_stu2
   end

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -88,7 +88,7 @@ module SMARTAppLaunch
 
       input :standalone_access_token, 
             title: 'Access Token',
-            description: 'The access token to be introspected.'
+            description: 'The access token to be introspected. MUST be active.'
 
 
       output :active_token_introspection_response_body

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -15,67 +15,46 @@ module SMARTAppLaunch
 
       If Inferno cannot reasonably be configured to be authorized to access the token introspection endpoint, these tests 
       can be skipped.  Instead, an out-of-band token introspection request must be completed and the response body
-      manually provided as input for the Token Introspection Response test group.
+      manually provided as input for the Validate Introspection Response test group.
       )
 
     input_instructions %(
-      By default, Inferno will aim to introspect the access token retrieved in the standalone launch tests. However,
-      the inputs can be modified and another active access token may be provided.  Either way, the token must be in an
-      active state in order for the test to pass.
+      If the Request New Access Token group was executed, the access token input will auto-populate with that token. 
+      Otherwise an active access token needs to be obtained out-of-band and input.  
         
-      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is currently dependent upon the authorization
-      server, but this is commonly a token that has been issued by this authorization server, is not expired, has not been
-      revoked, and is valid for use at the protected resource making the introspection call."
+      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is 
+      currently dependent upon the authorization server, but this is commonly a token that has been issued by this 
+      authorization server, is not expired, has not been revoked, and is valid for use at the protected resource making 
+      the introspection call."
 
-      If only a client ID is input, Inferno will assume this is a public client and not include an Authorization
-      header in the introspection request.  If a client ID and secret are provided, Inferno will default to 
-      an Authorization: Basic header.  For all other use cases, tester must provide their own authorization header
-      for the HTTP request.  
+      If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
+      [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
+      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
+      server to complete the introspection request.  All parameter values for both the header and the body must be input 
+      URI-encoded. 
     )
 
     input :well_known_introspection_url, 
           title: 'Token Introspection Endpoint URL', 
           description: 'The complete URL of the token introspection endpoint.'
-    
-    input :introspection_client_id, 
-          title: 'Client ID',
-          optional: true,
-          description: %(
-            ID of the client requesting introspection, as it is registered with the authorization server.
-          )
-
-    input :introspection_client_secret,
-          title: 'Client Secret',
-          optional: true,
-          description: %(
-            Provide to use Authorization: Basic header in introspection request.
-          )
-
-    input :custom_auth_method,
-          title: 'Use Custom HTTP Authorization Header',
-          type: 'radio',
-          default: 'false',
-          options: {
-            list_options: [
-              {
-                label: 'True',
-                value: 'true'
-              },
-              {
-                label: 'False',
-                value: 'false'
-              }
-            ]
-          }
 
     input :custom_authorization_header,
-          title: 'Custom HTTP Authorization Header for Introspection Request',
+          title: 'HTTP Authorization Header for Introspection Request',
           type: 'textarea',
           optional: true,
           description: %(
-            Include both header name and value.
+            Include both header name and encoded value.
             Ex: 'Authorization: Bearer 23410913-abewfq.123483' 
             )
+
+    input :optional_introspection_request_params,
+          title: 'Additional Introspection Request Parameters',
+          type: 'textarea',
+          optional: true,
+          description: %(
+            Any additional parameters required for the introspection request to succeed. Will be added to the request body.
+            Must be URI-encoded.  
+          )
 
     test do
       title 'Token introspection endpoint returns a response when provided an active token'

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -11,16 +11,26 @@ module SMARTAppLaunch
       This group of tests executes the token introspection requests and ensures the correct HTTP response is returned
       but does not validate the contents of the token introspection response. 
 
-      If Inferno cannot reasonably be configured to be authorized to access the token introspectione endpoint, these tests 
-      can be skipped.  Instead, an out of band token introspection request must be completed and the response body
-      provided as input for the next test group.  
+      If Inferno cannot reasonably be configured to be authorized to access the token introspection endpoint, these tests 
+      can be skipped.  Instead, an out-of-band token introspection request must be completed and the response body
+      manually provided as input for the Token Introspection Response test group.
       )
+
+    input_instructions %(
+      By default, Inferno will aim to introspect the access token retrieved in the standalone launch tests. However,
+      the inputs can be modified and another active access token may be provided.  Either way, the token must be in an
+      active state in order for the test to pass.
+        
+      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is currently dependent upon the authorization
+      server, but this is commonly a token that has been issued by this authorization server, is not expired, has not been
+      revoked, and is valid for use at the protected resource making the introspection call."
+    )
 
     input :token_endpoint_url, 
           description: 'The complete URL of the token introspection endpoint.'
     
     input :client_id, 
-          description: 'ID of the authorization server client requesting introspection'
+          description: 'ID of the client requesting introspection, as it is registered with the authorization server'
 
     input :authorization_required,
           type: 'radio',
@@ -54,13 +64,6 @@ module SMARTAppLaunch
       description %(
       This test will execute a token introspection request for an active token and ensure a 200 status and valid JSON
       body are returned in the response. 
-
-      By default, Inferno will aim to introspect the access token retrieved in the standalone launch tests. However,
-      the inputs can be modified and another active access token may be provided.
-        
-      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is currently dependent upon the authorization
-      server, but his is commonly a token that has been issued by this authorization server, is not expired, has not been
-      revoked, and is valid for use at the protected resource making the introspection call."
       )
       
       # TODO set default value from other test output

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -81,7 +81,7 @@ module SMARTAppLaunch
         body are returned in response. 
       )
 
-      output :inactive_token_introspection_response_body
+      output :invalid_token_introspection_response_body
       run do
         # headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         # body = "token=invalid_token_value"

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -2,30 +2,19 @@ require_relative 'token_exchange_test'
 require_relative 'token_refresh_body_test'
 
 module SMARTAppLaunch
-  class TokenIntrospectionTestGroup < Inferno::TestGroup
-    title 'Token Introspection Group'
+  class TokenIntrospectionRequestGroup < Inferno::TestGroup
+    title 'Token Introspection Request'
+    run_as_group
+
+    id :token_introspection_request_group
     description %(
-      # Background
-      OAuth 2.0 Token introspection, as described in [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662), allows
-      an authorized resource server to query an OAuth 2.0 authorization server for metadata on a token.  The
-      [SMART App Launch STU 2.1 Implementation Guide Section on Token Introspection](https://hl7.org/fhir/smart-app-launch/token-introspection.html)
-      states that "SMART on FHIR EHRs SHOULD support token introspection, which allows a broader ecosystem of resource servers
-      to leverage authorization decisions managed by a single authorization server."
+      This group of tests executes the token introspection requests and ensures the correct HTTP response is returned
+      but does not validate the contents of the token introspection response. 
 
-      # Test Methodology
-      For these tests, Inferno acts as an authorized resource server that queries the authorization server about an access 
-      token, rather than a client to a FHIR resource server as in the previous SMART App Launch tests.  The tests will 
-      create a request to the authorization server's token introspection endpoint and validate the introspection response.
-
-      The means of discovery of the token introspection endpoint are outside the scope of the RFC-7662 specification.
-      As such, Inferno makes no assumptions that that the introspection endpoint is included in the `.well-known` endpoint query and leaves it to be input by the user. 
-      
-      To complete the tests, Inferno should be registered with the authorization server as an authorized resource server
-      capable of accessing the token introspection endpoint.  RFC-7662 requires "some form of authorization" to access
-      the token endpoint but does specifiy any one specific approach.  
+      If Inferno cannot reasonably be configured to be authorized to access the token introspectione endpoint, these tests 
+      can be skipped.  Instead, an out of band token introspection request must be completed and the response body
+      provided as input for the next test group.  
       )
-
-    id :token_introspection_test_group
 
     DEFAULT_INTR_BASE_URL = 'http://localhost:8080/reference-server/'
     DEFAULT_TOKEN_ENDPOINT = 'protocol/openid-connect/token'
@@ -53,7 +42,7 @@ module SMARTAppLaunch
     end
 
     test do
-      title 'Token introspection endpoint returns correct response for active token'
+      title 'Token introspection endpoint returns a response when provided an active token'
       description %(
       This test will check whether the metadata in the token introspection response is correct for an active token and that the response data matches the data in the original access token and/or access token response from the authorization server, including the following:
       
@@ -204,7 +193,7 @@ module SMARTAppLaunch
     end
 
     test do 
-      title 'Token introspection endpoint returns correct response for invalid token with valid client ID'
+      title 'Token introspection endpoint returns a response when provided an invalid token'
       description %(
         This test will query the introspection endpoint and provide an invalid token in the form of a hardcoded string value.
         The authorization server must return a 200 OK status and have a response with no other data except an `active` claim, which must be set to false. 

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -37,15 +37,14 @@ module SMARTAppLaunch
           title: 'Token Introspection Endpoint URL', 
           description: 'The complete URL of the token introspection endpoint.'
     
-    input :standalone_client_id, 
+    input :introspection_client_id, 
           title: 'Client ID',
           optional: true,
           description: %(
             ID of the client requesting introspection, as it is registered with the authorization server.
-            Defaults to Standalone Client ID, if provided.
           )
 
-    input :standalone_client_secret,
+    input :introspection_client_secret,
           title: 'Client Secret',
           optional: true,
           description: %(

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -5,7 +5,7 @@ require_relative 'standalone_launch_group'
 
 module SMARTAppLaunch
   class TokenIntrospectionRequestGroup < Inferno::TestGroup
-    title 'Token Introspection Request'
+    title 'Issue Token Introspection Request'
     run_as_group
 
     id :token_introspection_request_group

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -1,4 +1,5 @@
 require_relative 'token_introspection_request_group'
+require_relative 'token_exchange_test'
 
 module SMARTAppLaunch
   class TokenIntrospectionResponseGroup < Inferno::TestGroup
@@ -56,29 +57,48 @@ module SMARTAppLaunch
         introspection response
       )
 
-      input :access_token_response_client_id,
-            description: 'The client ID from the original access token response body'
+      # Access token value is repeatedly overwritten during refresh token tests and value 
+      # when provided for introspection is from the last refresh token exchange test from standalone launch
+      # But other outputs (id token, received scopes, etc) do not update and are still the same as
+      # they were in the original access token request 
+      # Is there any contexts in which this could cause problems, i.e., the response body values from 
+      # using a refresh token grant are different than the response body values from the authorization code grant?
+
+      input :standalone_client_id,
+            title: 'Access Token Respone: client_id'
+
+      # TODO delete when verification done
+      input :standalone_access_token,
+            title: 'Access Token Introspected',
+            locked: true,
+            description: 'Included to ensure inputs are populating correctly, will delete later'
       
-      input :access_token_response_expires_in,
+      input :standalone_expires_in,
+            title: 'Access Token Response: expires_in',
             description: 'The expires_in value from the original access token response body'
 
-      input :access_token_response_scopes,
+      input :standalone_received_scopes,
+            title: 'Access Token Response: scope',
             description: 'A space-separated list of scopes from the original access token response body'
       
-      input :access_token_response_id_token,
+      input :standalone_id_token,
+            title: 'Access Token Response: id_token',
             type: 'textarea',
             optional: true,
             description: 'The ID token from the original access token response body, IF it was present'
 
-      input :access_token_response_patient,
+      input :standalone_patient_id,
+            title: 'Access Token Response (launch context): patient',
             optional: true,
             description: 'The value for patient context from the original access token response body, IF it was present'
 
-      input :access_token_response_encounter,
+      input :standalone_encounter_id,
+            title: 'Access Token Response (launch context): encounter',
             optional: true,
             description: 'The value for encounter context from the original access token response body, IF it was present'
 
       input :active_token_introspection_response_body,
+            title: 'Token Introspection Response Body',
             type: 'textarea',
             description: 'The JSON body of the token introspection response when provided an ACTIVE token'
 

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -1,0 +1,23 @@
+require_relative 'token_introspection_request_group'
+
+module SMARTAppLaunch
+  class TokenIntrospectionResponseGroup < Inferno::TestGroup
+    title 'Token Introspection Response'
+    run_as_group
+
+    id :token_introspection_response_group
+    description %(
+      This group of tests validates the contents of the token introspection response.  The inputs will default to the outputs
+      of the Standalone Launch test and/or Token Introspection Request tests if they were run; otherwise, input values
+      will need to be manually entered. 
+      )
+      
+    test do 
+      title 'Token introspection response for an active token contains required fields'
+    end
+
+    test do
+      title 'Token introspection response for an invalid token contains required fields'
+    end
+  end
+end

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -17,20 +17,13 @@ module SMARTAppLaunch
         There are two categories of input for this test group: 
 
         1. The access token response values, which will dictate what the tests will expect to find in the token 
-        introspection response.  If the Token Introspection Request test group was run AND the option to introspect
-        the access token from the Standalone Launch tests was selected, these values will auto-fill; otherwise,
-        the tester will need to run an out-of-band ACCESS TOKEN request and manually input the access token response
-        parameters.   
+        introspection response.  If the Request New Access Token group was run, these inputs will auto-populate.   
         
-        2. The token introspection response bodies. If the Token Introspection Request test group was run, these will
-        auto-fill; otherwise, the tester will need to an run out-of-band INTROSPECTION requests for:
+        2. The token introspection response bodies. If the Issue Introspection Request test group was run, these will
+        auto-populate; otherwise, the tester will need to an run out-of-band INTROSPECTION requests for a. An ACTIVE 
+        access token, AND b. An INACTIVE OR INVALID token 
 
-          a. The ACTIVE access token received from the out-of-band access token request, AND
-
-          b. An INACTIVE OR INVALID token 
-
-        The client making both introspection requests must be authorized to access the introspection endpoint if
-        the endpoint is protected.
+        See [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2) for details on active vs inactive tokens.
       )
       
     test do 
@@ -57,15 +50,8 @@ module SMARTAppLaunch
         introspection response
       )
 
-      # Access token value is repeatedly overwritten during refresh token tests and value 
-      # when provided for introspection is from the last refresh token exchange test from standalone launch
-      # But other outputs (id token, received scopes, etc) do not update and are still the same as
-      # they were in the original access token request 
-      # Is there any contexts in which this could cause problems, i.e., the response body values from 
-      # using a refresh token grant are different than the response body values from the authorization code grant?
-
       input :standalone_client_id,
-            title: 'Access Token Response: client_id',
+            title: 'Access Token client_id',
             description: 'ID of the client that requested the access token being introspected'
 
       # TODO delete when verification done
@@ -73,10 +59,6 @@ module SMARTAppLaunch
             title: 'Access Token Introspected',
             locked: true,
             description: 'Included to ensure inputs are populating correctly, will delete later'
-      
-      input :standalone_expires_in,
-            title: 'Access Token Response: expires_in',
-            description: 'The expires_in value from the original access token response body'
 
       input :standalone_received_scopes,
             title: 'Access Token Response: scope',
@@ -99,7 +81,7 @@ module SMARTAppLaunch
             description: 'The value for encounter context from the original access token response body, IF it was present'
 
       input :active_token_introspection_response_body,
-            title: 'Token Introspection Response Body',
+            title: 'Active Token Introspection Response Body',
             type: 'textarea',
             description: 'The JSON body of the token introspection response when provided an ACTIVE token'
 
@@ -121,6 +103,7 @@ module SMARTAppLaunch
       )
 
       input :inactive_token_introspection_response_body,
+            title: 'Inactive Token Introspection Response Body',
             type: 'textarea',
             description: 'The JSON body of the token introspection response when provided an INVALID or INACTIVE token'
     end

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -65,7 +65,8 @@ module SMARTAppLaunch
       # using a refresh token grant are different than the response body values from the authorization code grant?
 
       input :standalone_client_id,
-            title: 'Access Token Respone: client_id'
+            title: 'Access Token Response: client_id',
+            description: 'ID of the client that requested the access token being introspected'
 
       # TODO delete when verification done
       input :standalone_access_token,

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -54,14 +54,9 @@ module SMARTAppLaunch
             title: 'Access Token client_id',
             description: 'ID of the client that requested the access token being introspected'
 
-      # TODO delete when verification done
-      input :standalone_access_token,
-            title: 'Access Token Introspected',
-            locked: true,
-            description: 'Included to ensure inputs are populating correctly, will delete later'
 
       input :standalone_received_scopes,
-            title: 'Access Token Response: scope',
+            title: 'Expected Introspection Response Value: scopes',
             description: 'A space-separated list of scopes from the original access token response body'
       
       input :standalone_id_token,
@@ -71,14 +66,14 @@ module SMARTAppLaunch
             description: 'The ID token from the original access token response body, IF it was present'
 
       input :standalone_patient_id,
-            title: 'Access Token Response (launch context): patient',
+            title: 'Expected Introspection Response for Patient Launch Context Paramter',
             optional: true,
-            description: 'The value for patient context from the original access token response body, IF it was present'
+            description: 'The value for patient launch context from the original access token response body, IF it was present'
 
       input :standalone_encounter_id,
-            title: 'Access Token Response (launch context): encounter',
+            title: 'Expected Introspection Response for Encounter Launch Context Parameter',
             optional: true,
-            description: 'The value for encounter context from the original access token response body, IF it was present'
+            description: 'The value for encounter launch context from the original access token response body, IF it was present'
 
       input :active_token_introspection_response_body,
             title: 'Active Token Introspection Response Body',
@@ -102,10 +97,10 @@ module SMARTAppLaunch
         about an inactive token, including why the token is inactive."
       )
 
-      input :inactive_token_introspection_response_body,
-            title: 'Inactive Token Introspection Response Body',
+      input :invalid_token_introspection_response_body,
+            title: 'Invalid Token Introspection Response Body',
             type: 'textarea',
-            description: 'The JSON body of the token introspection response when provided an INVALID or INACTIVE token'
+            description: 'The JSON body of the token introspection response when provided an INVALID token'
     end
   end
 end

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -3,7 +3,7 @@ require_relative 'token_exchange_test'
 
 module SMARTAppLaunch
   class TokenIntrospectionResponseGroup < Inferno::TestGroup
-    title 'Token Introspection Response'
+    title 'Validate Token Introspection Response'
     run_as_group
 
     id :token_introspection_response_group

--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -7,17 +7,101 @@ module SMARTAppLaunch
 
     id :token_introspection_response_group
     description %(
-      This group of tests validates the contents of the token introspection response.  The inputs will default to the outputs
-      of the Standalone Launch test and/or Token Introspection Request tests if they were run; otherwise, input values
-      will need to be manually entered. 
+      This group of tests validates the contents of the token introspection response by comparing the fields and/or 
+      values in the token introspection response to the fields and/or values of the original access token response 
+      in which the access token was given to the client.   
+      )
+
+      input_instructions %(
+        There are two categories of input for this test group: 
+
+        1. The access token response values, which will dictate what the tests will expect to find in the token 
+        introspection response.  If the Token Introspection Request test group was run AND the option to introspect
+        the access token from the Standalone Launch tests was selected, these values will auto-fill; otherwise,
+        the tester will need to run an out-of-band ACCESS TOKEN request and manually input the access token response
+        parameters.   
+        
+        2. The token introspection response bodies. If the Token Introspection Request test group was run, these will
+        auto-fill; otherwise, the tester will need to an run out-of-band INTROSPECTION requests for:
+
+          a. The ACTIVE access token received from the out-of-band access token request, AND
+
+          b. An INACTIVE OR INVALID token 
+
+        The client making both introspection requests must be authorized to access the introspection endpoint if
+        the endpoint is protected.
       )
       
     test do 
       title 'Token introspection response for an active token contains required fields'
+
+      description %(
+        This test will check whether the metadata in the token introspection response is correct for an active token and
+         that the response data matches the data in the original access token and/or access token response from the 
+         authorization server, including the following:
+      
+        Required:
+        *  `active` claim is set to true 
+        * `scope`, `client_id`, and `exp` claim(s) match between introspection response and access token
+
+        Conditionally Required:
+        * IF launch context parameter(s) included in access token, introspection response includes claim(s) for 
+        launch context parameter(s) 
+          * Parameters checked for are `patient` and `encounter`
+        * IF identity token was included as part of access token response, `iss` and `sub` claims are present in 
+        introspection response
+
+        Optional but Recommended:
+        * IF identity token was included as part of access token response, `fhirUser` claim SHOULD be present in 
+        introspection response
+      )
+
+      input :access_token_response_client_id,
+            description: 'The client ID from the original access token response body'
+      
+      input :access_token_response_expires_in,
+            description: 'The expires_in value from the original access token response body'
+
+      input :access_token_response_scopes,
+            description: 'A space-separated list of scopes from the original access token response body'
+      
+      input :access_token_response_id_token,
+            type: 'textarea',
+            optional: true,
+            description: 'The ID token from the original access token response body, IF it was present'
+
+      input :access_token_response_patient,
+            optional: true,
+            description: 'The value for patient context from the original access token response body, IF it was present'
+
+      input :access_token_response_encounter,
+            optional: true,
+            description: 'The value for encounter context from the original access token response body, IF it was present'
+
+      input :active_token_introspection_response_body,
+            type: 'textarea',
+            description: 'The JSON body of the token introspection response when provided an ACTIVE token'
+
     end
 
     test do
       title 'Token introspection response for an invalid token contains required fields'
+
+      description %(
+        From [RFC7662 OAuth2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2):
+        "If the introspection call is properly authorized but the token is not
+        active, does not exist on this server, or the protected resource is
+        not allowed to introspect this particular token, then the
+        authorization server MUST return an introspection response with the
+        "active" field set to "false".  Note that to avoid disclosing too
+        much of the authorization server's state to a third party, the
+        authorization server SHOULD NOT include any additional information
+        about an inactive token, including why the token is inactive."
+      )
+
+      input :inactive_token_introspection_response_body,
+            type: 'textarea',
+            description: 'The JSON body of the token introspection response when provided an INVALID or INACTIVE token'
     end
   end
 end


### PR DESCRIPTION
# Summary
[Ticket FI-2251](https://oncprojectracking.healthit.gov/support/browse/FI-2251).  Re-organized test approach and organization based on feedback and discussions with ONC.  Includes an outline for tests, all inputs and outputs, and instructions/descriptions - does not include test bodies or assertions. The goal for this PR is to validate the structure of the tests prior to implementing them.  
 
This test structure supports 4 different workflows:
1. **Fully automated** - introspects the latest access token (obtained via refresh token) received in standalone launch tests.  This is the easiest and (hopefully) the most common use case.  Executes both Token Introspection Request and Token Introspection Response groups with little to no manual input required from tester.

2. **Automated access token request, manual introspection request** - reuses the access token from standalone launch tests, but the environment under test does not support Inferno accessing the introspection endpoint.  Requires tester to skip Token Introspection Request test group, run those requests out of band, and manually input introspection responses to Token Introspection Response test group.

3. **Manual access token request, automated introspection request** - if tester does not want to introspect the access token from standalone launch they can generate their own and provide it as an input to Token Introspection Request test.  Requires tester to manually provide the values they received in the access token response as inputs to the Token Introspection Response tests.

4.  **Fully manual** - the tester must manually request an access token to introspect and run the introspection requests.  Technically provides the most opportunity for testers to "cheat," since they are providing both the introspection content to be validated AND the access token response against which the introspection content is validated (i.e., they provide both the test questions and the test answers, so to speak).

## Notes & Issues
* Inclusion of client ID and client secret as inputs to Token Introspection Request tests
     * Originally we discussed only having an input for Authorization Header.  However, I had difficulty auto-populating this and ended up thinking of 3 different authorization options for the introspection endpoint:
          * public client/no access control - no authorization header needed, but a client ID is still required in request body (requires client ID as an input).  This will be assumed if client ID is input, authorization header is empty, and client secret is empty.
          * client credentials access - the preferred method of access control per the IG, requires a client secret.  To support more automation, I added client secret as an input to save the tester the work of creating their own authorization header. 
 Tests will assume that the presence of a client ID, presence of client secret, and absence of authorization header inputs will create an `Authorization: Basic` header from the client ID and secret inputs.
          * custom access mechanism - a catch-all for other ways.  If the Custom Authorization Header input has a value, it will be used.  
 
* Refresh token tests from standalone launch update the output value for the access token, but not other outputs from the access token request.  
     * To explain better, let's say the original access token request makes request A and outputs values for all fields in the access token response (standalone access token, standalone ID token, expires in, etc etc).  The last refresh token tests makes request D but only updates the output for standalone access token.  As a result, when we reuse the outputs from standalone launch tests in the token introspection tests, the standalone access token value will be from request D but all the other parameters' values will still be from request A.  
     * **It's unclear to me if this would realistically cause problems but seems like a potential source of errors/inconsistencies.** To fix this, we would need to update the test configuration inputs for the standalone launch tests. 

# Testing Guidance
Run the test kit and view in the web UI.  Token introspection tests have no implementation, but if you run the standalone launch tests with the reference server presets the test output values will auto-populate for introspection tests.  
