### PR TITLE
FI-2303 token introspection

### DIFF
--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -276,10 +276,10 @@ module SMARTAppLaunch
         Introspection.  If Standalone Launch tests were successfully executed, these inputs will auto-populate.
 
         If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
-        [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
-        approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
-        server to complete the introspection request.  All parameter values for both the header and the body must be input
-        URI-encoded.
+      [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
+      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
+      server to complete the introspection request.  **For both the Authorization header and request parameters, user-input
+      values will be sent exactly as entered and therefore the tester must URI-encode any appropriate values.**
       )
 
     end

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -251,7 +251,7 @@ module SMARTAppLaunch
       group from: :token_introspection_response_group
 
       input_order :well_known_introspection_url, :custom_authorization_header, :optional_introspection_request_params,
-                  :url, :client_id, :client_secret, :requested_scopes, :smart_authorization_url, :authorization_method,
+                  :url, :standalone_client_id, :standalone_client_secret, :smart_authorization_url, :authorization_method,
                   :use_pkce, :pkce_code_challenge_method
 
       input_instructions %(

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -58,6 +58,19 @@ module SMARTAppLaunch
       * `#{Inferno::Application[:base_url]}/custom/smart_stu2/.well-known/jwks.json`
     DESCRIPTION
 
+    input_instructions %(
+      When running tests at this level, group 3 Token Introspection will assume the token introspection endpoint 
+      will be output from group 1 Standalone Launch tests, specifically the SMART On FHIR Discovery tests that query
+      the .well-known/smart-configuration endpoint. However, including the token introspection
+      endpoint as part of the well-known ouput is NOT required and is not formally checked in the SMART On FHIR Discovery
+      tests.  RFC-7662 says that "The means by which the protected resource discovers the location of the introspection
+      endpoint are outside the scope of this specification" and the Token Introspection IG does not add any further
+      requirements on how the introspection endpoint is made available to the resource server.  
+
+      If the token introspection endpoint of the system under test is NOT available at .well-known/smart-configuration, 
+      please run the test groups individually; group 3 Token Introspection has the introspection as a manual input.  
+    )
+
     group do
       title 'Standalone Launch'
       id :smart_full_standalone_launch

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -59,16 +59,17 @@ module SMARTAppLaunch
     DESCRIPTION
 
     input_instructions %(
-      When running tests at this level, group 3 Token Introspection will assume the token introspection endpoint 
+      When running tests at this level, the token introspection endpoint is not available as a manual input.
+      Instead, group 3 Token Introspection will assume the token introspection endpoint 
       will be output from group 1 Standalone Launch tests, specifically the SMART On FHIR Discovery tests that query
       the .well-known/smart-configuration endpoint. However, including the token introspection
       endpoint as part of the well-known ouput is NOT required and is not formally checked in the SMART On FHIR Discovery
-      tests.  RFC-7662 says that "The means by which the protected resource discovers the location of the introspection
+      tests.  RFC-7662 on Token Introspection says that "The means by which the protected resource discovers the location of the introspection
       endpoint are outside the scope of this specification" and the Token Introspection IG does not add any further
-      requirements on how the introspection endpoint is made available to the resource server.  
+      requirements to this.  
 
       If the token introspection endpoint of the system under test is NOT available at .well-known/smart-configuration, 
-      please run the test groups individually; group 3 Token Introspection has the introspection as a manual input.  
+      please run the test groups individually and group 3 Token Introspection will include the introspection endpoint as a manual input.  
     )
 
     group do

--- a/lib/smart_app_launch/token_exchange_stu2_test.rb
+++ b/lib/smart_app_launch/token_exchange_stu2_test.rb
@@ -33,6 +33,7 @@ module SMARTAppLaunch
     input :client_auth_type,
           title: 'Client Authentication Method',
           type: 'radio',
+          default: 'public',
           options: {
             list_options: [
               {

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -61,8 +61,6 @@ module SMARTAppLaunch
       This test will execute a token introspection request for an active token and ensure a 200 status and valid JSON
       body are returned in the response. 
       )
-      
- 
 
       input :standalone_access_token, 
             title: 'Access Token',
@@ -77,14 +75,13 @@ module SMARTAppLaunch
         body = "token=#{standalone_access_token}"
 
         if custom_authorization_header.present?
-          # parse out contents 
-          # get key
-          # get value
-          # add to headers map
+          parsed_header = custom_authorization_header.split(':', 2)
+          assert parsed_header.length == 2, "Incorrect custom HTTP header format input, expected: '<header name>: <header value>'"
+          headers[parsed_header[0]] = parsed_header[1].strip
         end
 
         if optional_introspection_request_params.present?
-          # append to body string with '&' 
+          body += "&#{optional_introspection_request_params}"
         end
 
         post(well_known_introspection_url, body: body, headers: headers)

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -30,8 +30,8 @@ module SMARTAppLaunch
       If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
       [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
       approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
-      server to complete the introspection request.  All parameter values for both the header and the body must be input 
-      URI-encoded. 
+      server to complete the introspection request.  **For both the Authorization header and request parameters, user-input
+      values will be sent exactly as entered and therefore the tester must URI-encode any appropriate values.** 
     )
 
     input :well_known_introspection_url, 
@@ -43,8 +43,8 @@ module SMARTAppLaunch
           type: 'textarea',
           optional: true,
           description: %(
-            Include both header name and encoded value.
-            Ex: 'Authorization: Bearer 23410913-abewfq.123483' 
+            Include header name, auth scheme, and auth parameters.
+            Ex: 'Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW' 
             )
 
     input :optional_introspection_request_params,
@@ -52,8 +52,7 @@ module SMARTAppLaunch
           type: 'textarea',
           optional: true,
           description: %(
-            Any additional parameters required for the introspection request to succeed. Will be added to the request body.
-            Must be URI-encoded.  
+            Any additional parameters to append to the request body, separated by &. Example: 'param1=abc&param2=def'  
           )
 
     test do
@@ -76,6 +75,18 @@ module SMARTAppLaunch
 
         headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
         body = "token=#{standalone_access_token}"
+
+        if custom_authorization_header.present?
+          # parse out contents 
+          # get key
+          # get value
+          # add to headers map
+        end
+
+        if optional_introspection_request_params.present?
+          # append to body string with '&' 
+        end
+
         post(well_known_introspection_url, body: body, headers: headers)
 
         assert_response_status(200)


### PR DESCRIPTION
# Summary
Link to [Jira ticket](https://oncprojectracking.healthit.gov/support/browse/FI-2303)
Completed implementation of token introspection tests and thoroughly tested with a variety of inputs.  Includes all user-facing instructions and documentation.    

## Notes
- Adding SMART on FHIR discovery tests to group 3.1 adds a constraint that could break 3.2 and 3.3 tests, so I did not add this change as we had discussed
	- When SMART on FHIR discovery tests were added to group 3.1, the input field for token introspection endpoint disappeared  from the 3 - Token Introspection Run Tests menu.  The introspection endpoint is needed for group 3.2 (issue introspection request) and the group 3 input menu assumes this will be an automated output from group 3.1 (request new access token).  However, none of the IGs require that the introspection endpoint come from the well-known URL, so **it is possible that the `well_known_introspection_endpoint` will be EMPTY after running 3.1, breaking tests in 3.2 and 3.3.**  
	- The workarounds for this would all complicate the input menu and instructions ; I believe the most straightforward solution is to leave the SMART on FHIR discovery tests out of test group 3.1 and make the note instead that if test group 3 is run after test group 1 Standalone Launch, these inputs will auto-populate (including the well-known introspection endpoint IF it is available)

# Testing Guidance
- Set up and run the WIP reference server locally following the [instructions here](https://github.com/inferno-framework/inferno-reference-server/pull/112)
- Run this test kit using the inferno development setup 
- Navigate to localhost:4567 and select STU2 from menu
- Select Inferno Reference Server as the preset
- There are multiple ways to run tests
1.  The "full flow"
	- Run test group 1 Standalone Launch (will auto-populate endpoint values for group 3)
		- Replace default FHIR endpoint with: http://localhost:8080/reference-server/r4 and submit
		- You can click through the full authorization process or cancel (what matters is that the endpoint test completes) - note that if the full group runs, TLS tests will fail
	- Run test group 3 Token Introspection
		- Leave all default values selected and run, clicking through authorization process for group 3.1
2. Token Introspection tests on their own 
	- Select group 3 Token Introspection from the left-hand menu, then "Run All Tests" in the right hand corner
	- Add the following inputs and submit
		- Introspection Endpoint URL: http://localhost:8080/reference-server/oauth/token/introspect
		- Standalone FHIR Endpoint: http://localhost:8080/reference-server/r4
		- smart_authorization_url:  http://localhost:8080/reference-server/oauth/authorization
		- smart_token_url: http://localhost:8080/reference-server/oauth/token
- Either way, tests will fail
     - 3.1 will fail due to TLS, so ignore
     - 3.2 should pass
     - 3.3 will fail because introspection response doesn't have all required fields 
          - To get 3.3 tests to pass, need to tinker with JSON response inputs until tests pass (follow error outputs)
