### PR TITLE
FI-2469 README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,78 @@ for system resources.
 
 **id:** `backend_services_authorization`
 
-**inputs:** 
-* `smart_token_url` 
-* `backend_services_client_id` 
-* `backend_services_requested_scope` 
-* `client_auth_encryption_method`
-* `backend_services_jwks_kid` (optional)
+**inputs:** `smart_token_url`, `backend_services_client_id`,
+`backend_services_requested_scope`, `client_auth_encryption_method`, `backend_services_jwks_kid` (optional)
 
-**outputs:** 
-* `bearer_token`
+**outputs:**  `bearer_token`
+
+### Token Introspection Group 
+The [Token Introspection Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/token_introspection_group.rb)
+is only part of SMART App Launch STU 2.0 and is divided into three subgroups that
+can be run collectively or independently, depending on the constraints of the environment
+under test. 
+
+**id:** `smart_token_introspection`
+
+#### Token Introspection Access Token Group
+The [Token Introspection Access Token Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/token_introspection_access_token_group.rb) 
+reuses tests from the Discovery and Standalone Launch groups to retrieve the
+token endpoint and an access token for introspection.  This group is optional.   
+
+**id:** `smart_token_introspection_access_token_group`
+
+**inputs:** - if STU2 Discovery and Standalone Launch groups were already run successfully, these
+will all auto-populate with previously used values
+* `url`
+* `client_id`
+* `client_secret`
+* `requested_scopes`
+* `use_pkce`
+* `pkce_code_challenge_method`
+* `authorization_method`
+* `client_auth_type`
+* `client_auth_encryption_method`
+
+**outputs:** `standalone_access_token`
+
+#### Token Introspection Request Group
+The [Token Introspection Request Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/token_introspection_request_group.rb) 
+sends introspection requests for both a valid and invalid access token to the
+authorization server and ensure the appropriate HTTP response is returned.  This
+group is optional but recommended. 
+
+**id:** `smart_token_introspection_request_group`
+
+**inputs:**
+* `well_known_introspection_url` - auto-populated if Token Introspection Access
+  Token Group run successfully
+* `custom_authorization_header`
+* `optional_introspection_request_params`
+* `standalone_access_token` - auto-populated if Token Introspection Access Token
+  Group run successfully 
+
+**outputs:**
+* `active_token_introspection_response_body`
+* `invalid_token_introspection_response_body`
+
+#### Token Introspection Response Group
+The [Token Introspection Response Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/token_introspection_response_group.rb)
+validates the token introspection response returned from the authorization
+server.  This group is required to demonstrate token introspection capabilities. 
+
+**id:** `smart_token_introspection_response_group`
+
+**inputs:** if Token Introspection Response Group was already run
+successfully, these will all auto-populate 
+* `standalone_client_id`
+* `standalone_received_scopes`
+* `standalone_id_token`
+* `standalone_patient_id`
+* `standalone_encounter_id`
+* `active_token_introspection_response_body`
+* `invalid_token_introspection_response_body`
+
+**outputs:** none
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -233,17 +233,8 @@ token endpoint and an access token for introspection.  This group is optional.
 
 **id:** `smart_token_introspection_access_token_group`
 
-**inputs:** - if STU2 Discovery and Standalone Launch groups were already run successfully, these
-will all auto-populate with previously used values
-* `url`
-* `client_id`
-* `client_secret`
-* `requested_scopes`
-* `use_pkce`
-* `pkce_code_challenge_method`
-* `authorization_method`
-* `client_auth_type`
-* `client_auth_encryption_method`
+**inputs:** `url`, `client_id`, `client_secret`, `requested_scopes`, `use_pkce`,
+`pkce_code_challenge_method`, `authorization_method`, `client_auth_type`, `client_auth_encryption_method`
 
 **outputs:** `standalone_access_token`
 
@@ -255,13 +246,8 @@ group is optional but recommended.
 
 **id:** `smart_token_introspection_request_group`
 
-**inputs:**
-* `well_known_introspection_url` - auto-populated if Token Introspection Access
-  Token Group run successfully
-* `custom_authorization_header`
-* `optional_introspection_request_params`
-* `standalone_access_token` - auto-populated if Token Introspection Access Token
-  Group run successfully 
+**inputs:** `well_known_introspection_url`, `custom_authorization_header`,
+`optional_introspection_request_params`, `standalone_access_token` 
 
 **outputs:**
 * `active_token_introspection_response_body`
@@ -269,20 +255,15 @@ group is optional but recommended.
 
 #### Token Introspection Response Group
 The [Token Introspection Response Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/token_introspection_response_group.rb)
-validates the token introspection response returned from the authorization
+validates the token introspection responses returned from the authorization
 server.  This group is required to demonstrate token introspection capabilities. 
 
 **id:** `smart_token_introspection_response_group`
 
-**inputs:** if Token Introspection Response Group was already run
-successfully, these will all auto-populate 
-* `standalone_client_id`
-* `standalone_received_scopes`
-* `standalone_id_token`
-* `standalone_patient_id`
-* `standalone_encounter_id`
-* `active_token_introspection_response_body`
-* `invalid_token_introspection_response_body`
+**inputs:** `standalone_client_id`, `standalone_received_scopes`,
+`standalone_id_token`, `standalone_patient_id`, `standalone_encounter_id`,
+`active_token_introspection_response_body`,
+`invalid_token_introspection_response_body`
 
 **outputs:** none
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,28 @@ performs a token refresh.
 * `include_scopes`: (`true/false`) Whether to include scopes in the refresh
   request
 
+### Backend Services Authorization Group
+The [Backend Services Authorization Group](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/backend_services_authorization_group.rb)
+is only part of SMART App Launch STU 2.0. It is used when autonomous or
+semi-autonomous backend services (clients) need to access resources from FHIR
+servers that have pre-authorized, defined scopes of access.  This group appplies
+a client credentials flow using confidential client asymmetric
+authentication and JSON Web Token (JWT) assertions to retrieve an access token
+for system resources.
+
+**id:** `backend_services_authorization`
+
+**inputs:** 
+* `smart_token_url` 
+* `backend_services_client_id` 
+* `backend_services_requested_scope` 
+* `client_auth_encryption_method`
+* `backend_services_jwks_kid` (optional)
+
+**outputs:** 
+* `bearer_token`
+
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use


### PR DESCRIPTION
# Summary
Updated README to include sections for both Backend Services and Token Introspection, which were missing.  Used the same format as existing groups.

# Testing Guidance
Tests are not impacted.  Can verify markdown format by viewing rendered README for the branch. 
