### PR TITLE
FI-2470: Make Necessary Inputs Optional for New inferno_core Changes

### DIFF
--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -116,18 +116,14 @@ module SMARTAppLaunch
         in the table below to app developers. The server SHALL use both a FHIR
         CapabilityStatement and A Well-Known Uris JSON file.
       )
-        
-      input :well_known_management_url,
-            optional: true
-      input :well_known_registration_url,
-            optional: true
-      input :capability_management_url,
-            optional: true
-      input :capability_registration_url,
-            optional: true
+
       input :well_known_authorization_url,
             optional: true
       input :well_known_introspection_url,
+            optional: true
+      input :well_known_management_url,
+            optional: true
+      input :well_known_registration_url,
             optional: true
       input :well_known_revocation_url,
             optional: true
@@ -136,6 +132,10 @@ module SMARTAppLaunch
       input :capability_authorization_url,
             optional: true
       input :capability_introspection_url,
+            optional: true
+      input :capability_management_url,
+            optional: true
+      input :capability_registration_url,
             optional: true
       input :capability_revocation_url,
             optional: true

--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -116,16 +116,21 @@ module SMARTAppLaunch
         in the table below to app developers. The server SHALL use both a FHIR
         CapabilityStatement and A Well-Known Uris JSON file.
       )
+        
+      input :well_known_management_url,
+            optional: true
+      input :well_known_registration_url,
+            optional: true
+      input :capability_management_url,
+            optional: true
+      input :capability_registration_url,
+            optional: true
       input :well_known_authorization_url,
             :well_known_introspection_url,
-            :well_known_management_url,
-            :well_known_registration_url,
             :well_known_revocation_url,
             :well_known_token_url,
             :capability_authorization_url,
             :capability_introspection_url,
-            :capability_management_url,
-            :capability_registration_url,
             :capability_revocation_url,
             :capability_token_url
       output :smart_authorization_url,

--- a/lib/smart_app_launch/discovery_stu1_group.rb
+++ b/lib/smart_app_launch/discovery_stu1_group.rb
@@ -126,13 +126,21 @@ module SMARTAppLaunch
       input :capability_registration_url,
             optional: true
       input :well_known_authorization_url,
-            :well_known_introspection_url,
-            :well_known_revocation_url,
-            :well_known_token_url,
-            :capability_authorization_url,
-            :capability_introspection_url,
-            :capability_revocation_url,
-            :capability_token_url
+            optional: true
+      input :well_known_introspection_url,
+            optional: true
+      input :well_known_revocation_url,
+            optional: true
+      input :well_known_token_url,
+            optional: true
+      input :capability_authorization_url,
+            optional: true
+      input :capability_introspection_url,
+            optional: true
+      input :capability_revocation_url,
+            optional: true
+      input :capability_token_url,
+            optional: true
       output :smart_authorization_url,
              :smart_introspection_url,
              :smart_management_url,


### PR DESCRIPTION
# Summary
Before running each test, inferno_core now will check each input and will skip the test if an input is required and not populated. This PR fixes some issues that occur in the smart_app_launch test kit as a result, by making some test inputs optional that should not be causing the test to skip when they are not populated.
