### PR TITLE
FI-2479: Asymmetric token refresh

### DIFF
--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -7,7 +7,7 @@ require_relative 'standalone_launch_group_stu2'
 require_relative 'ehr_launch_group_stu2'
 require_relative 'openid_connect_group'
 require_relative 'token_introspection_group'
-require_relative 'token_refresh_group'
+require_relative 'token_refresh_stu2_group'
 require_relative 'backend_services_authorization_group'
 
 module SMARTAppLaunch
@@ -103,7 +103,7 @@ module SMARTAppLaunch
               }
             }
 
-      group from: :smart_token_refresh,
+      group from: :smart_token_refresh_stu2,
             id: :smart_standalone_refresh_without_scopes,
             title: 'SMART Token Refresh Without Scopes',
             config: {
@@ -123,7 +123,7 @@ module SMARTAppLaunch
               }
             }
 
-      group from: :smart_token_refresh,
+      group from: :smart_token_refresh_stu2,
             id: :smart_standalone_refresh_with_scopes,
             title: 'SMART Token Refresh With Scopes',
             config: {
@@ -179,7 +179,7 @@ module SMARTAppLaunch
               }
             }
 
-      group from: :smart_token_refresh,
+      group from: :smart_token_refresh_stu2,
             id: :smart_ehr_refresh_without_scopes,
             title: 'SMART Token Refresh Without Scopes',
             config: {
@@ -199,7 +199,7 @@ module SMARTAppLaunch
               }
             }
 
-      group from: :smart_token_refresh,
+      group from: :smart_token_refresh_stu2,
             id: :smart_ehr_refresh_with_scopes,
             title: 'SMART Token Refresh With Scopes',
             config: {

--- a/lib/smart_app_launch/token_refresh_stu2_group.rb
+++ b/lib/smart_app_launch/token_refresh_stu2_group.rb
@@ -1,0 +1,46 @@
+require_relative 'token_refresh_stu2_test'
+require_relative 'token_refresh_body_test'
+require_relative 'token_response_headers_test'
+
+module SMARTAppLaunch
+  class TokenRefreshSTU2Group < Inferno::TestGroup
+    id :smart_token_refresh_stu2
+    title 'SMART Token Refresh'
+    short_description 'Demonstrate the ability to exchange a refresh token for an access token.'
+    description %(
+      # Background
+
+      The #{title} Sequence tests the ability of the system to successfully
+      exchange a refresh token for an access token. Refresh tokens are typically
+      longer lived than access tokens and allow client applications to obtain a
+      new access token Refresh tokens themselves cannot provide access to
+      resources on the server.
+
+      Token refreshes are accomplished through a `POST` request to the token
+      exchange endpoint as described in the [SMART App Launch
+      Framework](https://www.hl7.org/fhir/smart-app-launch/1.0.0/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token).
+
+      # Test Methodology
+
+      This test attempts to exchange the refresh token for a new access token
+      and verify that the information returned contains the required fields and
+      uses the proper headers.
+
+      For more information see:
+
+      * [The OAuth 2.0 Authorization
+        Framework](https://tools.ietf.org/html/rfc6749)
+      * [Using a refresh token to obtain a new access
+        token](https://www.hl7.org/fhir/smart-app-launch/1.0.0/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)
+    )
+
+    test from: :smart_token_refresh_stu2
+    test from: :smart_token_refresh_body
+    test from: :smart_token_response_headers,
+         config: {
+           requests: {
+             token: { name: :token_refresh }
+           }
+         }
+  end
+end

--- a/lib/smart_app_launch/token_refresh_stu2_test.rb
+++ b/lib/smart_app_launch/token_refresh_stu2_test.rb
@@ -1,0 +1,46 @@
+require_relative 'token_refresh_test'
+
+module SMARTAppLaunch
+  class TokenRefreshSTU2Test < TokenRefreshTest
+    include TokenPayloadValidation
+
+    id :smart_token_refresh_stu2
+    title 'Server successfully refreshes the access token when optional scope parameter omitted'
+    description %(
+      Server successfully exchanges refresh token at OAuth token endpoint
+      without providing scope in the body of the request.
+
+      Although not required in the token refresh portion of the SMART App
+      Launch Guide, the token refresh response should include the HTTP
+      Cache-Control response header field with a value of no-store, as well as
+      the Pragma response header field with a value of no-cache to be
+      consistent with the requirements of the inital access token exchange.
+    )
+    input :client_auth_type
+    input :client_auth_encryption_method, optional: true
+    input :client_secret, optional: true
+
+    def add_credentials_to_request(oauth2_headers, oauth2_params)
+      case client_auth_type
+      when 'public'
+        oauth2_params['client_id'] = client_id
+      when 'confidential_symmetric'
+        assert client_secret.present?,
+               "A client secret must be provided when using confidential symmetric client authentication."
+
+        credentials = Base64.strict_encode64("#{client_id}:#{client_secret}")
+        oauth2_headers['Authorization'] = "Basic #{credentials}"
+      when 'confidential_asymmetric'
+        oauth2_params.merge!(
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: ClientAssertionBuilder.build(
+            iss: client_id,
+            sub: client_id,
+            aud: smart_token_url,
+            client_auth_encryption_method: client_auth_encryption_method
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/smart_app_launch/token_refresh_test.rb
+++ b/lib/smart_app_launch/token_refresh_test.rb
@@ -21,6 +21,15 @@ module SMARTAppLaunch
     output :smart_credentials, :token_retrieval_time
     makes_request :token_refresh
 
+    def add_credentials_to_request(oauth2_headers, oauth2_params)
+      if client_secret.present?
+        credentials = Base64.strict_encode64("#{client_id}:#{client_secret}")
+        oauth2_headers['Authorization'] = "Basic #{credentials}"
+      else
+        oauth2_params['client_id'] = client_id
+      end
+    end
+
     run do
       skip_if refresh_token.blank?
 
@@ -32,12 +41,7 @@ module SMARTAppLaunch
 
       oauth2_params['scope'] = received_scopes if config.options[:include_scopes]
 
-      if client_secret.present?
-        credentials = Base64.strict_encode64("#{client_id}:#{client_secret}")
-        oauth2_headers['Authorization'] = "Basic #{credentials}"
-      else
-        oauth2_params['client_id'] = client_id
-      end
+      add_credentials_to_request(oauth2_headers, oauth2_params)
 
       post(smart_token_url, body: oauth2_params, name: :token_refresh, headers: oauth2_headers)
 

--- a/spec/smart_app_launch/token_refresh_stu2_spec.rb
+++ b/spec/smart_app_launch/token_refresh_stu2_spec.rb
@@ -1,0 +1,238 @@
+require_relative '../../lib/smart_app_launch/token_refresh_stu2_test'
+require_relative '../request_helper'
+
+RSpec.describe SMARTAppLaunch::TokenRefreshSTU2Test do
+  include Rack::Test::Methods
+  include RequestHelpers
+
+  let(:test) { Inferno::Repositories::Tests.new.find('smart_token_refresh_stu2') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:requests_repo) { Inferno::Repositories::Requests.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'smart') }
+  let(:token_url) { 'http://example.com/fhir/token' }
+  let(:refresh_token) { 'REFRESH_TOKEN' }
+  let(:client_id) { 'CLIENT_ID' }
+  let(:client_secret) { 'CLIENT_SECRET' }
+  let(:received_scopes) { 'openid profile launch offline_access patient/*.*' }
+  let(:valid_response) do
+    {
+      access_token: 'ACCESS_TOKEN',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: received_scopes,
+      refresh_token: 'REFRESH_TOKEN2'
+    }
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name:,
+        value:,
+        type: runnable.config.input_type(name) || 'text'
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  it 'skips if no refresh_token is available' do
+    result = run(test, refresh_token: nil)
+
+    expect(result.result).to eq('skip')
+  end
+
+  context 'with a public client' do
+    let(:client_auth_type) { 'public'}
+
+    it 'passes when the refresh succeeds' do
+      stub_request(:post, token_url)
+        .to_return(
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: valid_response.to_json
+        )
+
+      result = run(
+        test,
+        smart_token_url: token_url,
+        refresh_token:,
+        client_id:,
+        received_scopes:,
+        client_auth_type:
+      )
+
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  context 'with a confidential symmetric client' do
+    let(:client_auth_type) { 'confidential_symmetric'}
+
+    it 'passes when the refresh succeeds' do
+      credentials = Base64.strict_encode64("#{client_id}:#{client_secret}")
+      stub_request(:post, token_url)
+        .with(
+          headers: {
+            Authorization: "Basic #{credentials}"
+          }
+        )
+        .to_return(
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: valid_response.to_json
+        )
+
+      result = run(
+        test,
+        smart_token_url: token_url,
+        refresh_token:,
+        client_id:,
+        client_secret:,
+        received_scopes:,
+        client_auth_type:
+      )
+
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  context 'with a confidential asymmetric client' do
+    let(:client_auth_type) { 'confidential_asymmetric' }
+
+    it 'passes when the refresh succeeds' do
+      stub_request(:post, token_url)
+        .to_return(
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: valid_response.to_json
+        )
+
+      result = run(
+        test,
+        smart_token_url: token_url,
+        refresh_token:,
+        client_id:,
+        client_secret:,
+        received_scopes:,
+        client_auth_type:,
+        client_auth_encryption_method: 'RS384'
+      )
+
+      expect(result.result).to eq('pass')
+    end
+  end
+
+  it 'fails if a non-200/201 response is received' do
+    stub_request(:post, token_url)
+      .to_return(
+        status: 202,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: valid_response.to_json
+      )
+
+    result = run(
+      test,
+      smart_token_url: token_url,
+      refresh_token:,
+      client_id:,
+      received_scopes:,
+      client_auth_type: 'public'
+    )
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/202/)
+  end
+
+  it 'fails if a non-json response is received' do
+    stub_request(:post, token_url)
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: '[['
+      )
+
+    result = run(
+      test,
+      smart_token_url: token_url,
+      refresh_token:,
+      client_id:,
+      received_scopes:,
+      client_auth_type: 'public'
+    )
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/Invalid JSON/)
+  end
+
+  it 'persists request' do
+    stub_request(:post, token_url)
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: valid_response.to_json
+      )
+
+    result = run(
+      test,
+      smart_token_url: token_url,
+      refresh_token:,
+      client_id:,
+      received_scopes:,
+      client_auth_type: 'public'
+    )
+
+    expect(result.result).to eq('pass')
+
+    request = requests_repo.find_named_request(test_session.id, :token_refresh)
+    expect(request).to be_present
+  end
+
+  context 'when the response does not contain a refresh token' do
+    it 'includes the original refresh token in the smart credentials' do
+      stub_request(:post, token_url)
+        .to_return(
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: valid_response.except(:refresh_token).to_json
+        )
+
+      result = run(
+        test,
+        smart_token_url: token_url,
+        refresh_token:,
+        client_id:,
+        received_scopes:,
+        client_auth_type: 'public'
+      )
+
+      expect(result.result).to eq('pass')
+
+      smart_credentials =
+        JSON.parse(
+          session_data_repo.load(
+            test_session_id: test_session.id,
+            name: :smart_credentials
+          )
+        ).symbolize_keys
+
+      expect(smart_credentials[:refresh_token]).to eq(refresh_token)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This branch updates the token refresh test when using STU2 to support asymmetric client auth.

# Testing Guidance
Use the reference server preset, select asymmetric auth, and set the client id to `SAMPLE_ASYMMETRIC_CLIENT_ID`. The refresh tests should pass, and you can inspect the refresh token requests and see that they are using asymmetric credentials.