### PR TITLE
FI-3053: Introspection URL Fix

### DIFF
--- a/lib/smart_app_launch/well_known_endpoint_test.rb
+++ b/lib/smart_app_launch/well_known_endpoint_test.rb
@@ -13,18 +13,9 @@ module SMARTAppLaunch
     input :url,
           title: 'FHIR Endpoint',
           description: 'URL of the FHIR endpoint used by SMART applications'
-    input :well_known_introspection_url,
-          title: 'Token Introspection Endpoint',
-          description: <<~DESCRIPTION,
-            The complete URL of the token introspection endpoint. This will be
-            populated automatically if included in the server's discovery
-            endpoint.
-          DESCRIPTION
-          optional: true
 
     output :well_known_configuration,
            :well_known_authorization_url,
-           :well_known_introspection_url,
            :well_known_management_url,
            :well_known_registration_url,
            :well_known_revocation_url,

--- a/lib/smart_app_launch/well_known_endpoint_test.rb
+++ b/lib/smart_app_launch/well_known_endpoint_test.rb
@@ -13,6 +13,15 @@ module SMARTAppLaunch
     input :url,
           title: 'FHIR Endpoint',
           description: 'URL of the FHIR endpoint used by SMART applications'
+    input :well_known_introspection_url,
+          title: 'Token Introspection Endpoint',
+          description: <<~DESCRIPTION,
+            The complete URL of the token introspection endpoint. This will be
+            populated automatically if included in the server's discovery
+            endpoint.
+          DESCRIPTION
+          optional: true
+
     output :well_known_configuration,
            :well_known_authorization_url,
            :well_known_introspection_url,
@@ -34,9 +43,12 @@ module SMARTAppLaunch
       base_url = "#{url.chomp('/')}/"
       config = JSON.parse(request.response_body)
 
+      if config['introspection_endpoint'].present?
+        output well_known_introspection_url: make_url_absolute(base_url, config['introspection_endpoint'])
+      end
+
       output well_known_configuration: request.response_body,
              well_known_authorization_url: make_url_absolute(base_url, config['authorization_endpoint']),
-             well_known_introspection_url: make_url_absolute(base_url, config['introspection_endpoint']),
              well_known_management_url: make_url_absolute(base_url, config['management_endpoint']),
              well_known_registration_url: make_url_absolute(base_url, config['registration_endpoint']),
              well_known_revocation_url: make_url_absolute(base_url, config['revocation_endpoint']),

--- a/lib/smart_app_launch/well_known_endpoint_test.rb
+++ b/lib/smart_app_launch/well_known_endpoint_test.rb
@@ -16,6 +16,7 @@ module SMARTAppLaunch
 
     output :well_known_configuration,
            :well_known_authorization_url,
+           :well_known_introspection_url,
            :well_known_management_url,
            :well_known_registration_url,
            :well_known_revocation_url,


### PR DESCRIPTION
# Summary

In the (g)(10) token introspection test, Inferno unexpectedly required and always used the introspection endpoint from the .well-known configuration, even though the introspection endpoint is only recommended to be included in .well-known. The Token Introspection Endpoint input was always ignored, which was problematic because if an introspection endpoint is not returned in .well-known, there is no way to pass the test.

This PR updates the SMART App Launch test kit's well-known test so that it only outputs the introspection endpoint if it is provided in .well-known. This will allow the Token Introspection Endpoint input to be used in (g)(10) if .well-known does not contain an introspection endpoint.

# Testing Guidance
I updated my local Inferno Reference server to not include an introspection endpoint in the .well-known response, and pulled this specific smart_app_launch branch into my locally running (g)(10) test kit to ensure it worked as expected.
