### PR TITLE
FI-3257: Use Custom Authorization Header Input in Invalid Token Test

### DIFF
--- a/lib/smart_app_launch/token_introspection_group.rb
+++ b/lib/smart_app_launch/token_introspection_group.rb
@@ -47,7 +47,7 @@ module SMARTAppLaunch
     input_order :url, :standalone_client_id, :standalone_client_secret,
                 :authorization_method, :use_pkce, :pkce_code_challenge_method,
                 :standalone_requested_scopes, :client_auth_encryption_method,
-                :client_auth_type, :custom_token_introspection_request_headers,
+                :client_auth_type, :custom_authorization_header,
                 :optional_introspection_request_params
     input_instructions %(
       Executing tests at this level will run all three Token Introspection groups back-to-back.  If test groups need

--- a/lib/smart_app_launch/token_introspection_group.rb
+++ b/lib/smart_app_launch/token_introspection_group.rb
@@ -47,7 +47,7 @@ module SMARTAppLaunch
     input_order :url, :standalone_client_id, :standalone_client_secret,
                 :authorization_method, :use_pkce, :pkce_code_challenge_method,
                 :standalone_requested_scopes, :client_auth_encryption_method,
-                :client_auth_type, :custom_authorization_header,
+                :client_auth_type, :custom_token_introspection_request_headers,
                 :optional_introspection_request_params
     input_instructions %(
       Executing tests at this level will run all three Token Introspection groups back-to-back.  If test groups need
@@ -57,13 +57,12 @@ module SMARTAppLaunch
 
       If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
       [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
-      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
+      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization
       server to complete the introspection request.
 
       **Note:** For both the Authorization header and request parameters, user-input
       values will be sent exactly as entered and therefore the tester must
       URI-encode any appropriate values.
     )
-
   end
 end

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -47,7 +47,9 @@ module SMARTAppLaunch
           description: %(
             Add custom headers for the introspection request by adding each header's name and value with a new line
             between each header.
-          )
+            Ex:
+              <Header 1 Name>: <Value 1>
+            )
 
     input :optional_introspection_request_params,
           title: 'Additional Introspection Request Parameters',

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -11,42 +11,46 @@ module SMARTAppLaunch
     id :smart_token_introspection_request_group
     description %(
       This group of tests executes the token introspection requests and ensures the correct HTTP response is returned
-      but does not validate the contents of the token introspection response. 
+      but does not validate the contents of the token introspection response.
 
-      If Inferno cannot reasonably be configured to be authorized to access the token introspection endpoint, these tests 
+      If Inferno cannot reasonably be configured to be authorized to access the token introspection endpoint, these tests
       can be skipped.  Instead, an out-of-band token introspection request must be completed and the response body
       manually provided as input for the Validate Introspection Response test group.
       )
 
     input_instructions %(
-      If the Request New Access Token group was executed, the access token input will auto-populate with that token. 
-      Otherwise an active access token needs to be obtained out-of-band and input.  
-        
-      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is 
-      currently dependent upon the authorization server, but this is commonly a token that has been issued by this 
-      authorization server, is not expired, has not been revoked, and is valid for use at the protected resource making 
+      If the Request New Access Token group was executed, the access token input will auto-populate with that token.
+      Otherwise an active access token needs to be obtained out-of-band and input.
+
+      Per [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2), "the definition of an active token is
+      currently dependent upon the authorization server, but this is commonly a token that has been issued by this
+      authorization server, is not expired, has not been revoked, and is valid for use at the protected resource making
       the introspection call."
 
       If the introspection endpoint is protected, testers must enter their own HTTP Authorization header for the introspection request.  See
       [RFC 7616 The 'Basic' HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common
-      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization 
+      approach that uses client credentials.  Testers may also provide any additional parameters needed for their authorization
       server to complete the introspection request.
 
       **Note:** For both the Authorization header and request parameters, user-input
       values will be sent exactly as entered and therefore the tester must URI-encode any appropriate values.
     )
 
-    input :well_known_introspection_url, 
-          title: 'Token Introspection Endpoint URL', 
+    input :well_known_introspection_url,
+          title: 'Token Introspection Endpoint URL',
           description: 'The complete URL of the token introspection endpoint.'
 
-    input :custom_authorization_header,
-          title: 'HTTP Authorization Header for Introspection Request',
+    input :custom_token_introspection_request_headers,
+          title: 'Custom HTTP Headers for Introspection Request',
           type: 'textarea',
           optional: true,
           description: %(
-            Include header name, auth scheme, and auth parameters.
-            Ex: 'Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW' 
+            Create an array of header name and value strings.
+            Ex:
+              [
+                "<Header 1 Name>: <Value 1>",
+                "<Header 2 Name>: <Value 2>"
+              ]
             )
 
     input :optional_introspection_request_params,
@@ -54,66 +58,70 @@ module SMARTAppLaunch
           type: 'textarea',
           optional: true,
           description: %(
-            Any additional parameters to append to the request body, separated by &. Example: 'param1=abc&param2=def'  
+            Any additional parameters to append to the request body, separated by &. Example: 'param1=abc&param2=def'
           )
 
     test do
       title 'Token introspection endpoint returns a response when provided an active token'
       description %(
       This test will execute a token introspection request for an active token and ensure a 200 status and valid JSON
-      body are returned in the response. 
+      body are returned in the response.
       )
 
-      input :standalone_access_token, 
+      input :standalone_access_token,
             title: 'Access Token',
             description: 'The access token to be introspected. MUST be active.'
-
 
       output :active_token_introspection_response_body
 
       run do
-
         # If this is being chained from an earlier test, it might be blank if not present in the well-known endpoint
         skip_if well_known_introspection_url.nil?, 'No introspection URL present in SMART well-known endpoint.'
 
-        headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }
         body = "token=#{standalone_access_token}"
 
-        if custom_authorization_header.present?
-          parsed_header = custom_authorization_header.split(':', 2)
-          assert parsed_header.length == 2, "Incorrect custom HTTP header format input, expected: '<header name>: <header value>'"
-          headers[parsed_header[0]] = parsed_header[1].strip
+        if custom_token_introspection_request_headers.present?
+          assert_valid_json(custom_token_introspection_request_headers)
+          custom_headers = JSON.parse(custom_token_introspection_request_headers)
+
+          assert(custom_headers.is_a?(Array), %(
+            Incorrect custom HTTP headers input format, expected:
+            ["<header 1 name>: <header 1 value>", "<header 2 name>: <header 2 value>", etc.]))
+
+          custom_headers.each do |custom_header|
+            parsed_header = custom_header.split(':', 2)
+            assert parsed_header.length == 2,
+                   'Incorrect custom HTTP header format input, expected: "<header name>: <header value>"'
+            headers[parsed_header[0]] = parsed_header[1].strip
+          end
         end
 
-        if optional_introspection_request_params.present?
-          body += "&#{optional_introspection_request_params}"
-        end
+        body += "&#{optional_introspection_request_params}" if optional_introspection_request_params.present?
 
-        post(well_known_introspection_url, body: body, headers: headers)
+        post(well_known_introspection_url, body:, headers:)
 
         assert_response_status(200)
         output active_token_introspection_response_body: request.response_body
       end
-    
     end
 
-    test do 
+    test do
       title 'Token introspection endpoint returns a response when provided an invalid token'
       description %(
         This test will execute a token introspection request for an invalid token and ensure a 200 status and valid JSON
-        body are returned in response. 
+        body are returned in response.
       )
 
       output :invalid_token_introspection_response_body
       run do
-
         # If this is being chained from an earlier test, it might be blank if not present in the well-known endpoint
         skip_if well_known_introspection_url.nil?, 'No introspection URL present in SMART well-known endpoint.'
 
-        headers = {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'}
-        body = "token=invalid_token_value"
-        post(well_known_introspection_url, body: body, headers: headers)
-        
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }
+        body = 'token=invalid_token_value'
+        post(well_known_introspection_url, body:, headers:)
+
         assert_response_status(200)
         output invalid_token_introspection_response_body: request.response_body
       end

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -40,7 +40,7 @@ module SMARTAppLaunch
           title: 'Token Introspection Endpoint URL',
           description: 'The complete URL of the token introspection endpoint.'
 
-    input :custom_token_introspection_request_headers,
+    input :custom_authorization_header,
           title: 'Custom HTTP Headers for Introspection Request',
           type: 'textarea',
           optional: true,
@@ -49,6 +49,8 @@ module SMARTAppLaunch
             between each header.
             Ex:
               <Header 1 Name>: <Value 1>
+
+
               <Header 2 Name>: <Value 2>
             )
 
@@ -80,8 +82,8 @@ module SMARTAppLaunch
         headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }
         body = "token=#{standalone_access_token}"
 
-        if custom_token_introspection_request_headers.present?
-          custom_headers = custom_token_introspection_request_headers.split("\n")
+        if custom_authorization_header.present?
+          custom_headers = custom_authorization_header.split("\n")
           custom_headers.each do |custom_header|
             parsed_header = custom_header.split(':', 2)
             assert parsed_header.length == 2,

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -112,6 +112,17 @@ module SMARTAppLaunch
 
         headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }
         body = 'token=invalid_token_value'
+
+        if custom_authorization_header.present?
+          custom_headers = custom_authorization_header.split("\n")
+          custom_headers.each do |custom_header|
+            parsed_header = custom_header.split(':', 2)
+            assert parsed_header.length == 2,
+                   'Incorrect custom HTTP header format input, expected: "<header name>: <header value>"'
+            headers[parsed_header[0]] = parsed_header[1].strip
+          end
+        end
+
         post(well_known_introspection_url, body:, headers:)
 
         assert_response_status(200)

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -47,10 +47,7 @@ module SMARTAppLaunch
           description: %(
             Add custom headers for the introspection request by adding each header's name and value with a new line
             between each header.
-            Ex:
-              <Header 1 Name>: <Value 1>
-              <Header 2 Name>: <Value 2>
-            )
+          )
 
     input :optional_introspection_request_params,
           title: 'Additional Introspection Request Parameters',

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -45,12 +45,11 @@ module SMARTAppLaunch
           type: 'textarea',
           optional: true,
           description: %(
-            Create an array of header name and value strings.
+            Add custom headers for the introspection request by adding each header's name and value with a new line
+            between each header.
             Ex:
-              [
-                "<Header 1 Name>: <Value 1>",
-                "<Header 2 Name>: <Value 2>"
-              ]
+              <Header 1 Name>: <Value 1>
+              <Header 2 Name>: <Value 2>
             )
 
     input :optional_introspection_request_params,
@@ -82,13 +81,7 @@ module SMARTAppLaunch
         body = "token=#{standalone_access_token}"
 
         if custom_token_introspection_request_headers.present?
-          assert_valid_json(custom_token_introspection_request_headers)
-          custom_headers = JSON.parse(custom_token_introspection_request_headers)
-
-          assert(custom_headers.is_a?(Array), %(
-            Incorrect custom HTTP headers input format, expected:
-            ["<header 1 name>: <header 1 value>", "<header 2 name>: <header 2 value>", etc.]))
-
+          custom_headers = custom_token_introspection_request_headers.split("\n")
           custom_headers.each do |custom_header|
             parsed_header = custom_header.split(':', 2)
             assert parsed_header.length == 2,

--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -49,8 +49,6 @@ module SMARTAppLaunch
             between each header.
             Ex:
               <Header 1 Name>: <Value 1>
-
-
               <Header 2 Name>: <Value 2>
             )
 


### PR DESCRIPTION
# Summary
Inferno allows test to specify authorization header for Token Introspection in the configuration input "HTTP Authorization Header for Introspection Request", but the invalid token test did not have the ability to use that custom header input. This PR adds the code to allow the invalid token test to use the custom authorization header input. This PR branch is branched off of https://github.com/inferno-framework/smart-app-launch-test-kit/pull/77, which is the PR that allows multi-line custom headers, so it includes those changes as well.

# Testing Guidance
Run test kit locally and ensure any headers added to the custom authorization header input are added to the request in the invalid token test.
