### PR TITLE
FI-3788: Add default redirect/launch/post auth uris

### DIFF
--- a/lib/smart_app_launch/app_launch_test.rb
+++ b/lib/smart_app_launch/app_launch_test.rb
@@ -10,7 +10,13 @@ module SMARTAppLaunch
     input :url
     receives_request :launch
 
-    config options: { launch_uri: "#{Inferno::Application['base_url']}/custom/smart/launch" }
+    def default_launch_uri
+      "#{Inferno::Application['base_url']}/custom/smart/launch"
+    end
+
+    def launch_uri
+      config.options[:launch_uri].presence || default_launch_uri
+    end
 
     def wait_message
       return instance_exec(&config.options[:launch_message_proc]) if config.options[:launch_message_proc].present?
@@ -21,7 +27,7 @@ module SMARTAppLaunch
         Waiting for Inferno to be launched from the EHR.
 
         Tests will resume once Inferno receives a launch request at
-        `#{config.options[:launch_uri]}` with an `iss` of `#{url}`.
+        `#{launch_uri}` with an `iss` of `#{url}`.
       )
     end
 

--- a/lib/smart_app_launch/app_redirect_test.rb
+++ b/lib/smart_app_launch/app_redirect_test.rb
@@ -47,7 +47,13 @@ module SMARTAppLaunch
     output :state, :pkce_code_challenge, :pkce_code_verifier
     receives_request :redirect
 
-    config options: { redirect_uri: "#{Inferno::Application['base_url']}/custom/smart/redirect" }
+    def default_redirect_uri
+      "#{Inferno::Application['base_url']}/custom/smart/redirect"
+    end
+
+    def redirect_uri
+      config.options[:redirect_uri].presence || default_redirect_uri
+    end
 
     def self.calculate_s256_challenge(verifier)
       Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
@@ -68,7 +74,7 @@ module SMARTAppLaunch
         [Follow this link to authorize with the SMART server](#{auth_url}).
 
         Tests will resume once Inferno receives a request at
-        `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+        `#{redirect_uri}` with a state of `#{state}`.
       )
     end
 
@@ -94,7 +100,7 @@ module SMARTAppLaunch
       oauth2_params = {
         'response_type' => 'code',
         'client_id' => client_id,
-        'redirect_uri' => config.options[:redirect_uri],
+        'redirect_uri' => redirect_uri,
         'scope' => requested_scopes,
         'state' => state,
         'aud' => aud

--- a/lib/smart_app_launch/app_redirect_test_stu2.rb
+++ b/lib/smart_app_launch/app_redirect_test_stu2.rb
@@ -32,12 +32,20 @@ module SMARTAppLaunch
             ]
           }
 
+    def default_post_authorization_uri
+      "#{Inferno::Application['base_url']}/custom/smart_stu2/post_auth"
+    end
+
+    def post_authorization_uri
+      config.options[:post_authorization_uri].presence || default_post_authorization_uri
+    end
+
     def authorization_url_builder(url, params)
       return super if authorization_method == 'get'
 
       post_params = params.merge(auth_url: url)
 
-      post_url = URI(config.options[:post_authorization_uri])
+      post_url = URI(post_authorization_uri)
       post_url.query = URI.encode_www_form(post_params)
       post_url.to_s
     end

--- a/lib/smart_app_launch/token_exchange_test.rb
+++ b/lib/smart_app_launch/token_exchange_test.rb
@@ -36,7 +36,13 @@ module SMARTAppLaunch
     uses_request :redirect
     makes_request :token
 
-    config options: { redirect_uri: "#{Inferno::Application['base_url']}/custom/smart/redirect" }
+    def default_redirect_uri
+      "#{Inferno::Application['base_url']}/custom/smart/redirect"
+    end
+
+    def redirect_uri
+      config.options[:redirect_uri].presence || default_redirect_uri
+    end
 
     def add_credentials_to_request(oauth2_params, oauth2_headers)
       if client_secret.present?
@@ -52,7 +58,7 @@ module SMARTAppLaunch
 
       oauth2_params = {
         code:,
-        redirect_uri: config.options[:redirect_uri],
+        redirect_uri:,
         grant_type: 'authorization_code'
       }
       oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }

--- a/spec/smart_app_launch/token_exchange_test_spec.rb
+++ b/spec/smart_app_launch/token_exchange_test_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
   let(:suite_id) { 'smart'}
   let(:url) { 'http://example.com/fhir' }
   let(:token_url) { 'http://example.com/token' }
+  let(:redirect_uri) { "#{Inferno::Application['base_url']}/custom/smart/redirect" }
   let(:public_inputs) do
     {
       code: 'CODE',
@@ -81,7 +82,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
               grant_type: 'authorization_code',
               code: 'CODE',
               client_id: 'CLIENT_ID',
-              redirect_uri: described_class.config.options[:redirect_uri]
+              redirect_uri:
             }
         )
         .to_return(status: 200, body: {}.to_json)
@@ -101,7 +102,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
             grant_type: 'authorization_code',
             code: 'CODE',
             client_id: 'CLIENT_ID',
-            redirect_uri: described_class.config.options[:redirect_uri]
+            redirect_uri:
           }
       )
       .to_return(status: 201)
@@ -132,7 +133,7 @@ RSpec.describe SMARTAppLaunch::TokenExchangeTest do
                 grant_type: 'authorization_code',
                 code: 'CODE',
                 client_id: 'CLIENT_ID',
-                redirect_uri: described_class.config.options[:redirect_uri],
+                redirect_uri:,
                 code_verifier: 'CODE_VERIFIER'
               }
           )


### PR DESCRIPTION
# Summary
Currently, any test kit importing the SMART App Launch tests must configure the url for POST authorization. This branch provides a default for the POST authorization url, as well as the redirect and launch urls so that they will work even when not configured.

# Testing Guidance
Run the US Core tests with SMART App Launch 2/2.2, select POST authorization, and you will receive a purple error. If you point US Core at this branch for the SMART App Launch Test Kit, you should no longer receive a purple error when using POST authorization.