### PR TITLE
Fix SMART Auth Input for Token Introspection Response Group

### DIFF
--- a/lib/smart_app_launch/token_introspection_response_group.rb
+++ b/lib/smart_app_launch/token_introspection_response_group.rb
@@ -53,7 +53,7 @@ module SMARTAppLaunch
         introspection response and should match the claim in the ID token
       )
 
-      input :standalone_smart_auth_info, type: :auth_info, options: { mode: 'auth' }
+      input :standalone_smart_auth_info, type: :auth_info, options: { mode: 'access' }
 
       input :standalone_received_scopes,
             title: 'Expected Introspection Response Value: scope',


### PR DESCRIPTION
# Summary
Update the SMART auth input for the `smart_token_introspection_response_group` so that is uses mode `access` rather than mode `auth`

# Testing Guidance
Ensure token introspection test still works as intended
