### PR TITLE
FI-3905: Backend Services Token Introspection Support

### DIFF
--- a/lib/smart_app_launch/backend_services_authorization_group.rb
+++ b/lib/smart_app_launch/backend_services_authorization_group.rb
@@ -31,8 +31,6 @@ module SMARTAppLaunch
             ]
           }
 
-    output :bearer_token, :received_scopes
-
     test from: :smart_tls,
          id: :smart_backend_services_token_tls_version,
          title: 'Authorization service token endpoint secured by transport layer security',

--- a/lib/smart_app_launch/backend_services_authorization_group.rb
+++ b/lib/smart_app_launch/backend_services_authorization_group.rb
@@ -31,7 +31,7 @@ module SMARTAppLaunch
             ]
           }
 
-    output :bearer_token
+    output :bearer_token, :received_scopes
 
     test from: :smart_tls,
          id: :smart_backend_services_token_tls_version,

--- a/lib/smart_app_launch/backend_services_authorization_request_success_test.rb
+++ b/lib/smart_app_launch/backend_services_authorization_request_success_test.rb
@@ -23,7 +23,7 @@ module SMARTAppLaunch
             ]
           }
 
-    output :authentication_response
+    output :authentication_response, :smart_auth_info
 
     run do
       post_request_content = BackendServicesAuthorizationRequestBuilder.build(
@@ -42,7 +42,8 @@ module SMARTAppLaunch
 
       smart_auth_info.issue_time = Time.now
 
-      output authentication_response: authentication_response.response_body
+      output authentication_response: authentication_response.response_body,
+             smart_auth_info: smart_auth_info
     end
   end
 end

--- a/lib/smart_app_launch/backend_services_authorization_request_success_test.rb
+++ b/lib/smart_app_launch/backend_services_authorization_request_success_test.rb
@@ -40,6 +40,8 @@ module SMARTAppLaunch
 
       assert_response_status([200, 201])
 
+      smart_auth_info.issue_time = Time.now
+
       output authentication_response: authentication_response.response_body
     end
   end

--- a/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
+++ b/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
@@ -42,8 +42,6 @@ module SMARTAppLaunch
       expires_in = response_body['expires_in']
 
       assert access_token.present?, 'Token response did not contain access_token as required'
-      assert received_scopes.present?, 'Token response did not contain scope as required'
-      assert expires_in.present?, 'Token response did not contain expires_in as required'
 
       smart_auth_info.access_token = access_token
       smart_auth_info.expires_in = expires_in

--- a/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
+++ b/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
@@ -29,7 +29,7 @@ module SMARTAppLaunch
               }
             ]
           }
-    output :bearer_token, :smart_auth_info
+    output :bearer_token, :smart_auth_info, :received_scopes
 
     run do
       skip_if authentication_response.blank?, 'No authentication response received.'
@@ -38,11 +38,15 @@ module SMARTAppLaunch
       response_body = JSON.parse(authentication_response)
 
       access_token = response_body['access_token']
+      received_scopes = response_body['scope']
+      expires_in = response_body['expires_in']
+
       assert access_token.present?, 'Token response did not contain access_token as required'
 
       smart_auth_info.access_token = access_token
+      smart_auth_info.expires_in = expires_in
 
-      output bearer_token: access_token, smart_auth_info: smart_auth_info
+      output bearer_token: access_token, smart_auth_info: smart_auth_info, received_scopes: received_scopes
 
       required_keys = ['token_type', 'expires_in', 'scope']
 

--- a/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
+++ b/lib/smart_app_launch/backend_services_authorization_response_body_test.rb
@@ -42,6 +42,8 @@ module SMARTAppLaunch
       expires_in = response_body['expires_in']
 
       assert access_token.present?, 'Token response did not contain access_token as required'
+      assert received_scopes.present?, 'Token response did not contain scope as required'
+      assert expires_in.present?, 'Token response did not contain expires_in as required'
 
       smart_auth_info.access_token = access_token
       smart_auth_info.expires_in = expires_in

--- a/lib/smart_app_launch/smart_stu2_2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_2_suite.rb
@@ -262,7 +262,8 @@ module SMARTAppLaunch
                 smart_auth_info: { name: :backend_services_smart_auth_info }
               },
               outputs: {
-                smart_auth_info: { name: :backend_services_smart_auth_info }
+                smart_auth_info: { name: :backend_services_smart_auth_info },
+                received_scopes: { name: :backend_services_received_scopes }
               }
             }
     end

--- a/lib/smart_app_launch/smart_stu2_suite.rb
+++ b/lib/smart_app_launch/smart_stu2_suite.rb
@@ -260,7 +260,8 @@ module SMARTAppLaunch
                 smart_auth_info: { name: :backend_services_smart_auth_info }
               },
               outputs: {
-                smart_auth_info: { name: :backend_services_smart_auth_info }
+                smart_auth_info: { name: :backend_services_smart_auth_info },
+                received_scopes: { name: :backend_services_received_scopes }
               }
             }
     end


### PR DESCRIPTION
# Summary
Updated the Backend Services tests so that they can be used with the token introspection tests. Required adding a few additional outputs to the Backend Services tests and updating smart auth info with some additional fields from the returned Backend Services authentication response.

# Testing Guidance
I tested out running this in the (j)(7) test suite from the j criteria test kit and the Backend Services tests can now be used to run the token introspection test. Note that the token introspection test fails right now because the token introspection response returned when passing in the token received from Backend Services is missing the required `client_id` and `exp` fields.

j criteria MR that uses this change: https://gitlab.mitre.org/inferno/onc-certification-j-criteria-test-kit/-/merge_requests/12