### PR TITLE
FI-4013: Allow 401 in invalid client responses in backend services

### DIFF
--- a/lib/smart_app_launch/backend_services_invalid_client_assertion_test.rb
+++ b/lib/smart_app_launch/backend_services_invalid_client_assertion_test.rb
@@ -44,7 +44,7 @@ module SMARTAppLaunch
 
       post(smart_auth_info.token_url, **post_request_content)
 
-      assert_response_status(400)
+      assert_response_status([400, 401])
     end
   end
 end

--- a/lib/smart_app_launch/backend_services_invalid_jwt_test.rb
+++ b/lib/smart_app_launch/backend_services_invalid_jwt_test.rb
@@ -55,7 +55,7 @@ module SMARTAppLaunch
 
       post(smart_auth_info.token_url, **post_request_content)
 
-      assert_response_status(400)
+      assert_response_status([400, 401])
     end
   end
 end

--- a/spec/smart_app_launch/backend_services_invalid_client_assertion_test_spec.rb
+++ b/spec/smart_app_launch/backend_services_invalid_client_assertion_test_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SMARTAppLaunch::BackendServicesInvalidClientAssertionTest do
     result = run(test, input)
 
     expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Unexpected response status: expected 400, but received 200')
+    expect(result.result_message).to match(/Unexpected response status:/)
   end
 
   it 'passes when token endpoint requires valid client_assertion_type' do

--- a/spec/smart_app_launch/backend_services_invalid_jwt_test_spec.rb
+++ b/spec/smart_app_launch/backend_services_invalid_jwt_test_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SMARTAppLaunch::BackendServicesInvalidJWTTest do
     result = run(test, input)
 
     expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Unexpected response status: expected 400, but received 200')
+    expect(result.result_message).to match(/Unexpected response status:/)
   end
 
   it 'passes when token endpoint requires valid JWT token' do


### PR DESCRIPTION
According to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2):
>          invalid_client
>               Client authentication failed (e.g., unknown client, no
>               client authentication included, or unsupported
>               authentication method).  The authorization server MAY
>               return an HTTP 401 (Unauthorized) status code to indicate
>               which HTTP authentication schemes are supported.  If the
>               client attempted to authenticate via the "Authorization"
>               request header field, the authorization server MUST
>               respond with an HTTP 401 (Unauthorized) status code and
>               include the "WWW-Authenticate" response header field
>               matching the authentication scheme used by the client.

The backend services tests were not allowing 401 for tests which produce invalid client errors. 