### PR TITLE
Fix typos and presets

### DIFF
--- a/config/presets/SMART_RunClientAgainstServer.json.erb
+++ b/config/presets/SMART_RunClientAgainstServer.json.erb
@@ -17,7 +17,7 @@
       "optional": true,
       "title": "SMART App Launch URL(s)",
       "type": "textarea",
-      "value": "http://localhost:4567/custom/smart_stu2_2/launch"
+      "value": "<%= Inferno::Application['base_url'] %>/custom/smart_stu2_2/launch"
     },
     {
       "name": "smart_redirect_uris",
@@ -25,7 +25,7 @@
       "optional": true,
       "title": "SMART App Launch Redirect URI(s)",
       "type": "textarea",
-      "value": "http://localhost:4567/custom/smart_stu2_2/redirect"
+      "value": "<%= Inferno::Application['base_url'] %>/custom/smart_stu2_2/redirect"
     },
     {
       "name": "smart_jwk_set",
@@ -33,7 +33,7 @@
       "optional": true,
       "title": "SMART Confidential Asymmetric JSON Web Key Set (JWKS)",
       "type": "textarea",
-      "value": "http://localhost:4567/custom/smart_stu2_2/.well-known/jwks.json"
+      "value": "<%= Inferno::Application['base_url'] %>/custom/smart_stu2_2/.well-known/jwks.json"
     },
     {
       "name": "smart_client_secret",

--- a/lib/smart_app_launch/endpoints/mock_smart_server.rb
+++ b/lib/smart_app_launch/endpoints/mock_smart_server.rb
@@ -119,7 +119,7 @@ module SMARTAppLaunch
           begin
             JSON.parse(retrieved.body)
           rescue JSON::ParserError
-            warning_messages << "Failed to fetch valid json from jwks uri #{jwk_set}."
+            warning_messages << "Failed to fetch valid json from jwks uri #{jku}."
             nil
           end
       else
@@ -163,7 +163,7 @@ module SMARTAppLaunch
       response.format = :json
       response.body = FHIR::OperationOutcome.new(
         issue: FHIR::OperationOutcome::Issue.new(severity: 'fatal', code: 'expired',
-                                                 details: FHIR::CodeableConcept.new(text: "#{type}has expired"))
+                                                 details: FHIR::CodeableConcept.new(text: "#{type} has expired"))
       ).to_json
     end
 


### PR DESCRIPTION
# Summary

Fix two typos that resulted in bad error messages in the UI and FHIR responses and update the client preset to use relative hosts.

# Testing Guidance

1. UI typo: run a client tests session selecting the backend services option. Run the Registration test group putting a url that doesn't resolve to a jwks in the "SMART Confidential Asymmetric JSON Web Key Set (JWKS)" input. Verify that the bad url shows up in the error messages.
2. expired token response typo: Run the Client suite selecting the backend services option on localhost:4567 against the server suite as described in the client suite description, but instead of using the access token obtained by the server suite use the following expired access token on the postman read request: eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0NjY0ODAwLCJub25jZSI6IjBiMDllZjRmNDY5MjcxOGIifQ. Verify that the returned error text has a space between "token" and "has".

