### PR TITLE
FI-3973: decouple client credentials tokens from suite options

### DIFF
--- a/lib/smart_app_launch/docs/smart_stu2_2_client_suite_description.md
+++ b/lib/smart_app_launch/docs/smart_stu2_2_client_suite_description.md
@@ -52,7 +52,7 @@ at a minimum by the tester to execute any tests in this suite:
   A comma-separated list of one or more URIs that the app will sepcify as the target
   of the redirect for Inferno to use when providing the authorization code.
 - **SMART Confidential Symmetric Client Secret** (required for the *SMART App Launch Confidential
-  Symmetric* clients only)): The client secret that the confidential symmetric client will send with
+  Symmetric* clients only): The client secret that the confidential symmetric client will send with
   token requests to authenticate the client to Inferno.
 - **SMART JSON Web Key Set (JWKS)** (required for *Confidential Asymmetric* clients): The SMART
   client's public JSON Web Key Set including key(s) that Inferno will use to verify the signature

--- a/lib/smart_app_launch/endpoints/mock_smart_server.rb
+++ b/lib/smart_app_launch/endpoints/mock_smart_server.rb
@@ -78,7 +78,7 @@ module SMARTAppLaunch
       return unless token_to_decode.present?
       
       JSON.parse(Base64.urlsafe_decode64(token_to_decode))
-    rescue JSON::ParserError
+    rescue StandardError
       nil
     end
 

--- a/lib/smart_app_launch/endpoints/mock_smart_server/token_endpoint.rb
+++ b/lib/smart_app_launch/endpoints/mock_smart_server/token_endpoint.rb
@@ -23,13 +23,13 @@ module SMARTAppLaunch
       end
 
       def make_response
+        return make_smart_client_credential_token_response if request.params[:grant_type] == CLIENT_CREDENTIALS_TAG
+        
         suite_options_list = Inferno::Repositories::TestSessions.new.find(result.test_session_id)&.suite_options
         suite_options_hash = suite_options_list&.map { |option| [option.id, option.value] }&.to_h
         smart_authentication_approach = SMARTClientOptions.smart_authentication_approach(suite_options_hash)
         
         case request.params[:grant_type]
-        when CLIENT_CREDENTIALS_TAG
-          make_smart_client_credential_token_response
         when AUTHORIZATION_CODE_TAG
           make_smart_authorization_code_token_response(smart_authentication_approach)
         when REFRESH_TOKEN_TAG


### PR DESCRIPTION
# Summary

Currently, token responses require suite options to be setup. Now, if a suite only offers backend services, like the bulk test kit, then no suite options need to be defined.

# Testing Guidance

- run rspec
- test as a part of the [bulk data client auth PR](https://github.com/inferno-framework/bulk-data-test-kit/pull/48)