### PR TITLE
FI-4079 Disable PKCE for SMART v1 test by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-22
   x86_64-darwin-23

--- a/lib/smart_app_launch/ehr_launch_group.rb
+++ b/lib/smart_app_launch/ehr_launch_group.rb
@@ -66,6 +66,10 @@ module SMARTAppLaunch
                 name: :auth_request_method,
                 default: 'GET',
                 locked: true
+              },
+              {
+                name: :pkce_support,
+                default: 'disabled'
               }
             ]
           }

--- a/lib/smart_app_launch/standalone_launch_group.rb
+++ b/lib/smart_app_launch/standalone_launch_group.rb
@@ -63,6 +63,10 @@ module SMARTAppLaunch
                 name: :auth_request_method,
                 default: 'GET',
                 locked: true
+              },
+              {
+                name: :pkce_support,
+                default: 'disabled'
               }
             ]
           }


### PR DESCRIPTION
# Summary

This PR fixes FI-4079 SMART v1 test configuration shall default to pkce be disabled

# What's Changed:

Add configuration to set PKCE as disabled for SMART v1 EHR launch test and Standalone launch test

# Testing Guidance

Run "SMART App Launch STU1" Test Suite
Do NOT select preset
Verify that PKCE Disabled is selected for "SMART App Launch STU1", "Standalone Launch", and "EHR Launch"

