### PR TITLE
Apply optional_introspection_request_params in invalid-token test

### DIFF
--- a/lib/smart_app_launch/token_introspection_request_group.rb
+++ b/lib/smart_app_launch/token_introspection_request_group.rb
@@ -121,6 +121,8 @@ module SMARTAppLaunch
           end
         end
 
+        body += "&#{optional_introspection_request_params}" if optional_introspection_request_params.present?
+
         post(well_known_introspection_url, body:, headers:)
 
         assert_response_status(200)


### PR DESCRIPTION
## Summary

The two token-introspection request tests share a group-level
`optional_introspection_request_params` input but only Test 01
(active-token) appends it to the request body. Test 02 (invalid-token)
builds the body from scratch and never applies the input.

Result on a server that requires those params — e.g. a
`client_id` + `client_secret` pair the introspection endpoint expects
on every request — Test 01 returns 200 as advertised while Test 02
returns 401 and fails, even though the tester supplied the same input
for both.

## Fix

One-liner: mirror line 90 from Test 01 into Test 02, right before
`post(well_known_introspection_url, ...)`.

## Test plan

- [x] Local diff against `main` shows the single added line inside
      Test 02's `run do` block.
- [x] Test 01 unchanged; the append happens at the same relative
      position (after the custom-headers loop, before the POST).
- [ ] Live re-run against the reporter's SMART server (a Rust
      implementation whose introspection endpoint is client-credential
      guarded): Test 02 flips from 401 → 200 with the fix applied.